### PR TITLE
Readme changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "services"]
 	path = services
-	url = http://github.com/cloudfoundry/vcap-services.git
+	url = https://github.com/cloudfoundry/vcap-services.git
 [submodule "tests"]
 	path = tests
-	url = http://github.com/cloudfoundry/vcap-tests.git
+	url = https://github.com/cloudfoundry/vcap-tests.git
 [submodule "java"]
 	path = java
-	url = http://github.com/cloudfoundry/vcap-java.git
+	url = https://github.com/cloudfoundry/vcap-java.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "services"]
 	path = services
-	url = git@github.com:cloudfoundry/vcap-services.git
+	url = http://github.com/cloudfoundry/vcap-services.git
 [submodule "tests"]
 	path = tests
-	url = git@github.com:cloudfoundry/vcap-tests.git
+	url = http://github.com/cloudfoundry/vcap-tests.git
 [submodule "java"]
 	path = java
-	url = git@github.com:cloudfoundry/vcap-java.git
+	url = http://github.com/cloudfoundry/vcap-java.git

--- a/README
+++ b/README
@@ -119,7 +119,7 @@ additional instructions for this environment have been included.
     #    this ends up mounting the services and tests repos in the directory tree of vcap
     #
     # 2) any time you git pull in vcap, you must also git submodule update
-    git clone git@github.com:cloudfoundry/vcap.git
+    git clone https://github.com/cloudfoundry/vcap.git
     
     # note, there should be a .rvmrc file in vcap/rvmrc
     # make sure that the vcap/.rvmrc is present and that it contains

--- a/README
+++ b/README
@@ -178,7 +178,7 @@ additional instructions for this environment have been included.
   For support visit support@cloudfoundry.com
 
   Target:   http://api.vcap.me (v0.999)
-  Client:   v0.3.7
+  Client:   v0.3.10
 
 
   #play around as a user, start with


### PR DESCRIPTION
I switched the submodules and readme to use the https:// style git urls, so that users won't be _required_ to have ssh keys on github to pull down submodules. I also added a small fix to some sample output, based on what I saw from my system while installing.
