### PR TITLE
Remove working directory dependency

### DIFF
--- a/bin/vcap
+++ b/bin/vcap
@@ -135,7 +135,7 @@ class Component
         # Make sure db is setup, this is slow and we should make it faster, but
         # should help for now.
         if is_cloud_controller?
-          `cd ../cloud_controller; rake db:migrate`
+          `cd #{File.dirname(__FILE__)}/cloud_controller; rake db:migrate`
         end
         exec("#{component_start_path}")
       end

--- a/bin/vcap
+++ b/bin/vcap
@@ -135,7 +135,7 @@ class Component
         # Make sure db is setup, this is slow and we should make it faster, but
         # should help for now.
         if is_cloud_controller?
-          Dir.chdir("#{File.dirname(__FILE__)}/cloud_controller") { `rake db:migrate` }
+          Dir.chdir("#{File.dirname(__FILE__)}/../cloud_controller") { `rake db:migrate` }
         end
         exec("#{component_start_path}")
       end

--- a/bin/vcap
+++ b/bin/vcap
@@ -135,7 +135,7 @@ class Component
         # Make sure db is setup, this is slow and we should make it faster, but
         # should help for now.
         if is_cloud_controller?
-          `cd #{File.dirname(__FILE__)}/cloud_controller; rake db:migrate`
+          Dir.chdir("#{File.dirname(__FILE__)}/cloud_controller") { `rake db:migrate` }
         end
         exec("#{component_start_path}")
       end


### PR DESCRIPTION
`./bin/vcap` currently requires that you're in `./bin` in order to run `vcap start`. This patch removes that dependency.
