### PR TITLE
Align service type names with values in their gateway configs

### DIFF
--- a/cloud_controller/app/models/service.rb
+++ b/cloud_controller/app/models/service.rb
@@ -97,11 +97,13 @@ class Service < ActiveRecord::Base
   def synthesize_service_type
     case self.name
     when /mysql/
-      'database'
+      'relational'
     when /redis/
       'key-value'
     when /mongodb/
-      'key-value'
+      'document'
+    when /rabbit/
+      'message-queue'
     else
       'generic'
     end


### PR DESCRIPTION
MongoDB should not be labeled as a key-value store, it's a document store.  MySQL is a relational database.  Also adding detection for RabbitMQ.
