### PR TITLE
Rename README to README.rdoc so Github formats it

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= VMware Cloud Application Platform
+= VMware's Cloud Application Platform
 
 Copyright (c) 2009-2011 VMware, Inc.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,5 @@
+= VMware Cloud Application Platform
+
 Copyright (c) 2009-2011 VMware, Inc.
 
 == What is Cloud Foundry?


### PR DESCRIPTION
Right now the README shows up in raw form on Github because there's no file
extension on it. Adding a .rdoc extension makes Github process it as RDoc
and convert it into nicely formatted HTML.

In addition I tried adding a heading taking my best guess at what "vcap"
actually stands for. The README should probably have some kind of heading
even if it's just "VCAP".
