### PR TITLE
Add JRuby support

### DIFF
--- a/cloud_controller/app/models/app.rb
+++ b/cloud_controller/app/models/app.rb
@@ -19,7 +19,7 @@ class App < ActiveRecord::Base
 
   AppStates = %w[STOPPED STARTED]
   PackageStates = %w[PENDING STAGED FAILED]
-  Runtimes = %w[ruby18 ruby19 java node]
+  Runtimes = %w[ruby18 ruby19 jruby java node]
   Frameworks = %w[sinatra rails3 spring grails node unknown]
 
   validates_presence_of :name, :framework, :runtime

--- a/cloud_controller/app/models/app.rb
+++ b/cloud_controller/app/models/app.rb
@@ -19,7 +19,7 @@ class App < ActiveRecord::Base
 
   AppStates = %w[STOPPED STARTED]
   PackageStates = %w[PENDING STAGED FAILED]
-  Runtimes = %w[ruby18 ruby19 jruby java node]
+  Runtimes = %w[ruby18 ruby19 jruby18 jruby19 java node]
   Frameworks = %w[sinatra rails3 spring grails node unknown]
 
   validates_presence_of :name, :framework, :runtime

--- a/cloud_controller/staging/manifests/rails3.yml
+++ b/cloud_controller/staging/manifests/rails3.yml
@@ -18,10 +18,18 @@ runtimes:
        rails_env: "production"
        bundle_gemfile:
        rack_env: "production"
-  - "jruby":
+  - "jruby18":
       version: "1.8.7p330"
       description: "JRuby 1.6.1"
       executable: "jruby"
+      environment:
+       rails_env: "production"
+       bundle_gemfile:
+       rack_env: "production"
+  - "jruby19":
+      version: "1.9.2"
+      description: "JRuby 1.6.1 (Ruby 1.9 mode)"
+      executable: "jruby --1.9"
       environment:
        rails_env: "production"
        bundle_gemfile:

--- a/cloud_controller/staging/manifests/rails3.yml
+++ b/cloud_controller/staging/manifests/rails3.yml
@@ -18,6 +18,14 @@ runtimes:
        rails_env: "production"
        bundle_gemfile:
        rack_env: "production"
+  - "jruby":
+      version: "1.8.7p330"
+      description: "JRuby 1.6.1"
+      executable: "jruby"
+      environment:
+       rails_env: "production"
+       bundle_gemfile:
+       rack_env: "production"
 app_servers:
   - "thin":
       description: "Thin"

--- a/cloud_controller/staging/manifests/rails3.yml
+++ b/cloud_controller/staging/manifests/rails3.yml
@@ -29,7 +29,7 @@ runtimes:
   - "jruby19":
       version: "1.9.2"
       description: "JRuby 1.6.1 (Ruby 1.9 mode)"
-      executable: "jruby --1.9"
+      executable: "jruby19"
       environment:
        rails_env: "production"
        bundle_gemfile:

--- a/cloud_controller/staging/manifests/sinatra.yml
+++ b/cloud_controller/staging/manifests/sinatra.yml
@@ -18,10 +18,18 @@ runtimes:
        rails_env: "production"
        bundle_gemfile:
        rack_env: "production"
-  - "jruby":
+  - "jruby18":
       version: "1.8.7p330"
       description: "JRuby 1.6.1"
       executable: "jruby"
+      environment:
+       rails_env: "production"
+       bundle_gemfile:
+       rack_env: "production"
+  - "jruby19":
+      version: "1.9.2"
+      description: "JRuby 1.6.1 (Ruby 1.9 mode)"
+      executable: "jruby --1.9"
       environment:
        rails_env: "production"
        bundle_gemfile:

--- a/cloud_controller/staging/manifests/sinatra.yml
+++ b/cloud_controller/staging/manifests/sinatra.yml
@@ -18,6 +18,14 @@ runtimes:
        rails_env: "production"
        bundle_gemfile:
        rack_env: "production"
+  - "jruby":
+      version: "1.8.7p330"
+      description: "JRuby 1.6.1"
+      executable: "jruby"
+      environment:
+       rails_env: "production"
+       bundle_gemfile:
+       rack_env: "production"
 app_servers:
   - "thin":
       description: "Thin"

--- a/cloud_controller/staging/manifests/sinatra.yml
+++ b/cloud_controller/staging/manifests/sinatra.yml
@@ -29,7 +29,7 @@ runtimes:
   - "jruby19":
       version: "1.9.2"
       description: "JRuby 1.6.1 (Ruby 1.9 mode)"
-      executable: "jruby --1.9"
+      executable: "jruby19"
       environment:
        rails_env: "production"
        bundle_gemfile:

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -27,10 +27,17 @@ runtimes:
     version_flag: "-e 'puts RUBY_VERSION'"
     additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 180'"
     environment:
-  jruby:
-    executable: jruby
+  jruby18:
+    executable: "jruby"
     version: 1.6.1
     version_flag: "-e 'puts JRUBY_VERSION'"
+    additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 174'"
+    environment:
+  jruby19:
+    executable: "jruby --1.9"
+    version: 1.6.1
+    version_flag: "-e 'puts JRUBY_VERSION'"
+    additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 136'" # JRuby is on 136 :/
     environment:
   node:
     executable: node

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -27,6 +27,11 @@ runtimes:
     version_flag: "-e 'puts RUBY_VERSION'"
     additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 180'"
     environment:
+  jruby:
+    executable: jruby
+    version: 1.6.1
+    version_flag: "-e 'puts JRUBY_VERSION'"
+    environment:
   node:
     executable: node
     version: 0.4.[2-9]

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -34,7 +34,7 @@ runtimes:
     additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 174'"
     environment:
   jruby19:
-    executable: "jruby --1.9"
+    executable: "jruby19"
     version: 1.6.1
     version_flag: "-e 'puts JRUBY_VERSION'"
     additional_checks: "-e 'puts RUBY_PATCHLEVEL >= 136'" # JRuby is on 136 :/

--- a/setup/vcap_setup
+++ b/setup/vcap_setup
@@ -183,6 +183,23 @@ if [[ $DEA == true || $ALL == true ]]; then
 	fi
     fi
 
+    # JRuby
+    JRUBY_VERSION=1.6.1
+    JRUBY_TARBALL=jruby-bin-$JRUBY_VERSION.tar.gz
+    
+    if [[ ! `jruby -e 'puts JRUBY_VERSION'` == $JRUBY_VERSION ]]; then
+	echo "Installing JRuby $JRUBY_VERSION"
+	wget -O /usr/local/jruby-bin-$JRUBY_VERSION.tar.gz http://jruby.org.s3.amazonaws.com/downloads/1.6.1/$JRUBY_TARBALL
+	tar -C /usr/local -zxf /usr/local/$JRUBY_TARBALL
+	rm -fr /usr/local/$JRUBY_TARBALL /usr/local/jruby
+	mv /usr/local/jruby-$JRUBY_VERSION /usr/local/jruby
+	ln -fs /usr/local/jruby/bin/jruby /usr/local/bin/jruby
+
+	# FIXME: Gem installation is deffered for MRI.
+	# Maybe JRuby should do the same?
+	jruby -S gem install jruby-openssl bundler thin trinidad sinatra
+    fi
+
     # Node
     pushd .
     cd /tmp
@@ -210,6 +227,9 @@ if [[ $DEA == true || $ALL == true ]]; then
 
     echo -e "\nJava should now be installed -->"
     java -version
+
+    echo -e "\nJRuby should now be installed -->"
+    jruby -v
 
     echo -e "\nNode should now be installed -->"
     node -v

--- a/setup/vcap_setup
+++ b/setup/vcap_setup
@@ -195,6 +195,11 @@ if [[ $DEA == true || $ALL == true ]]; then
 	mv /usr/local/jruby-$JRUBY_VERSION /usr/local/jruby
 	ln -fs /usr/local/jruby/bin/jruby /usr/local/bin/jruby
 
+	# Wrapper script for 1.9 support on JRuby
+	sed s/JRUBY_OPTS=\"/JRUBY_OPTS=\"--1.9/ /usr/local/jruby/bin/jruby > /usr/local/jruby/bin/jruby19
+	chmod +x /usr/local/jruby/bin/jruby19
+	ln -fs /usr/local/jruby/bin/jruby19 /usr/local/bin/jruby19
+
 	# FIXME: Gem installation is deffered for MRI.
 	# Maybe JRuby should do the same?
 	jruby -S gem install jruby-openssl bundler thin trinidad sinatra


### PR DESCRIPTION
I'm aware you can deploy warbled Rack applications into the Java runtime. That said, this allows you to deploy natively onto JRuby just as you would any other Ruby interpreter without the need to warble your application.

On my local copy of vcap I edited the staging manifest for Sinatra and made jruby the default runtime. I was successfully able to launch a "Hello, world!" Sinatra app on JRuby with this configuration. It launched under Thin through JRuby 1.6's C extension support. Real world usage of JRuby should probably launch the trinidad web server instead of thin, which I had the setup script install but didn't yet add to the manifest.

As far as I can tell there's no other way to select a runtime other than hand editing the manifest files, so I'm not sure how useful this is right now or if it's even wanted. All that said, it's at the proof-of-concept stage and works with Sinatra.
