### PR TITLE
Enforce ulimits in dea by default and offer a preference to disable

### DIFF
--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -9,6 +9,7 @@ log_level: DEBUG
 multi_tenant: true
 max_memory: 4096
 secure: false
+enforce_ulimit: true
 pid: /var/vcap/sys/run/dea.pid
 
 # This is where the execution agent determines its available runtimes.

--- a/dea/config/dea2.yml
+++ b/dea/config/dea2.yml
@@ -9,6 +9,7 @@ log_level: DEBUG
 multi_tenant: true
 max_memory: 4096
 secure: false
+enforce_ulimit: true
 pid: /var/vcap/sys/run/dea2.pid
 
 # This is where the execution agent determines its available runtimes.

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -76,6 +76,7 @@ module DEA
       @logger = VCAP.create_logger('dea', :log_file => config['log_file'], :log_rotation_interval => config['log_rotation_interval'])
       @logger.level = config['log_level']
       @secure = config['secure']
+      @enforce_ulimit = config['enforce_ulimit']
 
       @droplets = {}
       @usage = {}
@@ -610,7 +611,7 @@ module DEA
 
         exec_operation = proc do |process|
           process.send_data("cd #{instance_dir}\n")
-          if @secure
+          if @enforce_ulimit
             process.send_data("ulimit -m #{mem_kbytes} 2> /dev/null\n")  # ulimit -m takes kb, soft enforce
             process.send_data("ulimit -v 3000000 2> /dev/null\n") # virtual memory at 3G, this will be enforced
             process.send_data("ulimit -n #{num_fds} 2> /dev/null\n")

--- a/dea/spec/functional/agent_spec.rb
+++ b/dea/spec/functional/agent_spec.rb
@@ -28,6 +28,7 @@ describe 'DEA Agent' do
     'multi_tenant' => true,
     'max_memory'   => 4096,
     'secure'       => false,
+    'enforce_ulimit' => true,
     'local_route'  => 'localhost',
     'pid'          => File.join(TEST_DIR, 'dea.pid'),
     'runtimes'     => {


### PR DESCRIPTION
It seems to me I can think of several cases where you'd want to still set ulimits without running in secure mode (mainly protection from "Apps gone wild!" even if you don't need user segmentation).

I looked at the specs for dea and didn't see an obvious place to add tests for this trivial patch, but still think it is worth considering for merge. Open to suggestions and thoughts on that.
