### PR TITLE
Add pid files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ci-working-dir
 *.rbc
 *.swp
 .rvmrc
+*.pid
+


### PR DESCRIPTION
This commit adds *.pid to the .gitignore file to prevent accidental commit of pid files.
