### PR TITLE
Fix support contact from email to support website

### DIFF
--- a/cloud_controller/app/controllers/default_controller.rb
+++ b/cloud_controller/app/controllers/default_controller.rb
@@ -5,7 +5,7 @@ class DefaultController < ApplicationController
     info = {
       :name => 'vcap',
       :build => 2222,
-      :support =>  'support@cloudfoundry.com',
+      :support =>  'http://support.cloudfoundry.com',
       :version =>  CloudController.version,
       :description =>  'VMware\'s Cloud Application Platform'
     }


### PR DESCRIPTION
Currently _vmc info_ banner lists the following

```
$ vmc info

VMware's Cloud Application Platform
For support visit support@cloudfoundry.com

Target:   http://api.cloudfoundry.com (v0.999)
Client:   v0.3.10

User:     user@email.com
Usage:    Memory   (512.0M of 2.0G total)
          Services (1 of 16 total)
          Apps     (1 of 20 total)
```

The fix proposes changing the second line to 

```
For support visit http://support.cloudfoundry.com
```

as this information is gotten from VMC::INFO_PATH
