### PR TITLE
Move description and support address to an application config option

### DIFF
--- a/cloud_controller/app/controllers/default_controller.rb
+++ b/cloud_controller/app/controllers/default_controller.rb
@@ -5,9 +5,9 @@ class DefaultController < ApplicationController
     info = {
       :name => 'vcap',
       :build => 2222,
-      :support =>  'support@cloudfoundry.com',
+      :support =>  AppConfig[:support_address],
       :version =>  CloudController.version,
-      :description =>  'VMware\'s Cloud Application Platform'
+      :description =>  AppConfig[:description]
     }
     # If there is a logged in user, give out additional information
     if user

--- a/cloud_controller/config/appconfig.rb
+++ b/cloud_controller/config/appconfig.rb
@@ -30,6 +30,8 @@ env_overrides = {:local_route => 'CLOUD_CONTROLLER_HOST',
                  :rails_environment => 'RAILS_ENV'}
 
 required = { :external_uri => 'api.vcap.me',
+             :description => 'VMware\'s Cloud Application Platform',
+             :support_address => 'http://support.cloudfoundry.com',
              :rails_environment => 'development',
              :local_route  => '127.0.0.1',
              :local_register_only => true,

--- a/cloud_controller/config/cloud_controller.yml
+++ b/cloud_controller/config/cloud_controller.yml
@@ -1,5 +1,7 @@
 ---
 external_uri: api.vcap.me
+description: "VMware's Cloud Application Platform"
+support_address: http://support.cloudfoundry.com
 local_route: 127.0.0.1
 local_register_only: false
 


### PR DESCRIPTION
This request expands upon the change @svaiyapu suggested in cloudfoundry/vcap#71

It changes the support address by default from an e-mail address to the CloudFoundry support site - and allows individuals to change the support address and description using application config variables
