### PR TITLE
Adding to Install Instructions for Rack-based Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ the following steps
 
 #### Step 3: start the system
 
-    cd ~/cloudfoundry/vcap
+    cd ~/cloudfoundry/vcap && bundle install
     bin/vcap start
     bin/vcap tail  # see aggregate logs
 


### PR DESCRIPTION
Post-install 'bundle install' needs to be run from ~/cloudfoundry/vcap or the Sinatra example in the readme will throw a error. I'm just updating the install instructions so new users don't have to go chasing a solution.

For more info:
http://support.cloudfoundry.com/entries/20124152-rubygems-load-error-when-starting-the-app
