### PR TITLE
[PATCH] Cannot use MySQL as the cloud controller database due to invalid mysql_fiber_patch.

### DIFF
--- a/cloud_controller/vendor/plugins/mysql_fiber_patch/init.rb
+++ b/cloud_controller/vendor/plugins/mysql_fiber_patch/init.rb
@@ -1,6 +1,6 @@
 db_config = Rails.application.config.database_configuration[::Rails.env]
 if db_config['adapter'] == 'em_mysql2'
-  require File.expand_path('active_record_fiber_patches', __FILE__)
+  require File.expand_path('../active_record_fiber_patches', __FILE__)
   ActiveRecord::ConnectionAdapters.register_fiber_pool(CloudController::UTILITY_FIBER_POOL)
 end
 


### PR DESCRIPTION
Hi, 

I tried to use MySQL as the cloud controller database, using the 'em_mysql2' adapter.
And I found a small bug in mysql_fiber_patch.

For applying the patch attached with this request, you can use MySQL with configuring cloud_controller.yml as follows:

```
development:
    database: cloudcontroller
    host: localhost
    port: 3306
    username: root
    password: password
    adapter: em_mysql2
    encoding: utf8
    timeout: 2000
```

Thanks.
