### PR TITLE
Fix Typo in vcap_setup script

### DIFF
--- a/dev_setup/cookbooks/ruby/recipes/default.rb
+++ b/dev_setup/cookbooks/ruby/recipes/default.rb
@@ -5,7 +5,7 @@ rubygems_version = node[:rubygems][:version]
 bundler_version = node[:rubygems][:bundler][:version]
 rake_version = node[:rubygems][:rake][:version]
 
-%w[ build-essential libssl-dev zlib1g-dev libreadline5-dev libxml2-dev ].each do |pkg|
+%w[ build-essential libssl-dev zlib1g-dev libreadline5-dev libxml2-dev libpq-dev].each do |pkg|
   package pkg
 end
 

--- a/setup/vcap_setup
+++ b/setup/vcap_setup
@@ -257,7 +257,7 @@ if [[ $DEA == true || $ALL == true ]]; then
 
     ERLANG_VERSION=R14B02
 
-    if [ ! -d "/var/vcap/runtimes/erlang$ERLANG_VERSION" ]; then
+    if [ ! -d "/var/vcap/runtimes/erlang-$ERLANG_VERSION" ]; then
         if [[ $PLATFORM == 'Linux' ]]; then
             apt-get -qqy install build-essential libncurses5-dev openssl libssl-dev
         elif [[ $PLATFORM == 'MacOSX' ]]; then


### PR DESCRIPTION
There's a missing hyphen in the vcap_setup script when checking for a preexisting Erlang install. This is a quick fix.
