### PR TITLE
Adding support for (optional) configuring of port ranges for the DEA droplets.

### DIFF
--- a/common/lib/vcap/common.rb
+++ b/common/lib/vcap/common.rb
@@ -34,6 +34,26 @@ module VCAP
     socket.close
     return port
   end
+   
+  def self.grab_port_in_range port_range  
+      port_array = port_range.to_a
+      while (port_array.size > 0)
+       begin
+         index = rand(port_array.size)
+         port = port_array[index]
+         socket = TCPServer.new('127.0.0.1', port)
+         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+         Socket.do_not_reverse_lookup = true
+         p = socket.addr[1]
+         socket.close
+         return p
+       rescue
+         port_array.delete_at index
+       end
+     end
+
+    return nil
+  end
 
   def self.uptime_string(delta)
     num_seconds = delta.to_i

--- a/common/lib/vcap/common.rb
+++ b/common/lib/vcap/common.rb
@@ -34,26 +34,6 @@ module VCAP
     socket.close
     return port
   end
-   
-  def self.grab_port_in_range port_range  
-      port_array = port_range.to_a
-      while (port_array.size > 0)
-       begin
-         index = rand(port_array.size)
-         port = port_array[index]
-         socket = TCPServer.new('127.0.0.1', port)
-         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
-         Socket.do_not_reverse_lookup = true
-         p = socket.addr[1]
-         socket.close
-         return p
-       rescue
-         port_array.delete_at index
-       end
-     end
-
-    return nil
-  end
 
   def self.uptime_string(delta)
     num_seconds = delta.to_i

--- a/common/lib/vcap/common.rb
+++ b/common/lib/vcap/common.rb
@@ -35,6 +35,26 @@ module VCAP
     return port
   end
 
+  def self.grab_port_in_range port_range
+      port_array = port_range.to_a
+      while (port_array.size > 0)
+       begin
+         index = rand(port_array.size)
+         port = port_array[index]
+         socket = TCPServer.new('127.0.0.1', port)
+         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+         Socket.do_not_reverse_lookup = true
+         p = socket.addr[1]
+         socket.close
+         return p
+       rescue
+         port_array.delete_at index
+       end
+     end
+
+    return nil
+  end
+
   def self.uptime_string(delta)
     num_seconds = delta.to_i
     days = num_seconds / (60 * 60 * 24);

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -2,7 +2,6 @@
 base_dir: /var/vcap.local/dea
 local_route: 127.0.0.1
 filer_port: 12345
-port_range: 34600..45000
 mbus: nats://localhost:4222/
 intervals:
   heartbeat: 10

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -2,6 +2,7 @@
 base_dir: /var/vcap.local/dea
 local_route: 127.0.0.1
 filer_port: 12345
+#port_range: 34600..45000
 mbus: nats://localhost:4222/
 intervals:
   heartbeat: 10

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -2,6 +2,7 @@
 base_dir: /var/vcap.local/dea
 local_route: 127.0.0.1
 filer_port: 12345
+port_range: 34600..45000
 mbus: nats://localhost:4222/
 intervals:
   heartbeat: 10

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -86,6 +86,8 @@ module DEA
 
       @downloads_pending = {}
 
+      @port_range = process_range config['port_range'] if config['port_range']
+
       @shutting_down = false
 
       # Path to the ruby executable the dea should use when executing the prepare script.
@@ -131,6 +133,31 @@ module DEA
 
       # XXX(mjp) - Ugh, this is needed for VCAP::Component.register(). Find a better solution when time permits.
       @config = config.dup()
+    end
+
+    def process_range port_range
+      case port_range.count('.')
+         when 2     # we have an inclusive upper bound
+             ports = port_range.split('..')
+             Float(ports[0])  # ugly testing whether we have valid numbers
+             Float(ports[1])
+             if (ports[0].to_i <= ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
+               return Range.new(ports[0].to_i, ports[1].to_i)
+             end
+         when 3    # we have an exclusive upper bound
+             ports = port_range.split('...')
+             Float(ports[0])
+             Float(ports[1])
+             if (ports[0].to_i < ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
+               return Range.new(ports[0].to_i, ports[1].to_i - 1)
+             end
+         end
+
+      return nil
+
+      # wrongly formatted number. return nil
+      rescue
+        return nil
     end
 
     def run()
@@ -557,7 +584,12 @@ module DEA
       end
 
       start_operation = proc do
-        port = VCAP.grab_ephemeral_port
+         # fallback variant in case we cannot get a port in the configured range: use an ephemeral port
+        if @port_range
+          port = VCAP.grab_port_in_range @port_range || VCAP.grab_ephemeral_port
+        else
+          port =  VCAP.grab_ephemeral_port
+        end
 
         @logger.debug('Completed download')
         @logger.info("Starting up instance #{instance[:log_id]} on port:#{port}")

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -95,8 +95,6 @@ module DEA
 
       @runtimes = config['runtimes']
 
-      @port_range = process_range config['port_range'] if config['port_range']
-
       @local_ip     = VCAP.local_ip(config['local_route'])
       @max_memory   = config['max_memory'] # in MB
       @multi_tenant = config['multi_tenant']
@@ -133,30 +131,6 @@ module DEA
 
       # XXX(mjp) - Ugh, this is needed for VCAP::Component.register(). Find a better solution when time permits.
       @config = config.dup()
-    end
-     
-    def process_range port_range            
-      case port_range.count('.')
-         when 2     # we have an inclusive upper bound
-             ports = port_range.split('..')
-             Float(ports[0])  # ugly testing whether we have valid numbers
-             Float(ports[1])
-             if (ports[0].to_i <= ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
-               return Range.new(ports[0].to_i, ports[1].to_i)
-             end            
-         when 3    # we have an exclusive upper bound
-             ports = port_range.split('...')
-             Float(ports[0])
-             Float(ports[1])
-             if (ports[0].to_i < ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
-               return Range.new(ports[0].to_i, ports[1].to_i - 1)  
-             end                   
-         end    
-         
-      return nil
-      
-      rescue
-        return nil
     end
 
     def run()
@@ -583,13 +557,7 @@ module DEA
       end
 
       start_operation = proc do
-
-        # fallback variant in case we cannot get a port in the configured range: use an ephemeral port
-        if @port_range
-          port = VCAP.grab_port_in_range @port_range || VCAP.grab_ephemeral_port
-        else
-           port =  VCAP.grab_ephemeral_port
-        end
+        port = VCAP.grab_ephemeral_port
 
         @logger.debug('Completed download')
         @logger.info("Starting up instance #{instance[:log_id]} on port:#{port}")


### PR DESCRIPTION
Currently, the DEA nodes use the ephemeral port range from the underlying OS, for picking up a port number to supply to each droplet. This range can be configured, and probably the network stack should be restarted for the change to take effect. 

This pull request provides a new configuration property for DEA nodes: port_range, which allows you to specify some range, in terms of Ruby range literal, that will be considered when choosing the port. DEA will try to pick up a random port within the range, which is free, if possible. If this fails, fallback a variant is applied, which is the default behaviour - using the ephemeral port range. This has the advantage that only the DEA must be restarted in order for the configuration change to take effect.

In a secured corporate setup, the allowed network ports are restricted and tightly controlled. Most administrators would require to be able to specify some port range, rather than having them randomly chosen.
