### PR TITLE
Adding support for (optional) configuring of port ranges for the DEA droplets.

### DIFF
--- a/common/lib/vcap/common.rb
+++ b/common/lib/vcap/common.rb
@@ -35,6 +35,26 @@ module VCAP
     return port
   end
 
+  def self.grab_port_in_range port_range
+      port_array = port_range.to_a
+      while (port_array.size > 0)
+       begin
+         index = rand(port_array.size)
+         port = port_array[index]
+         socket = TCPServer.new('127.0.0.1', port)
+         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+         Socket.do_not_reverse_lookup = true
+         p = socket.addr[1]
+         socket.close
+         return p
+       rescue
+         port_array.delete_at index
+       end
+     end
+
+    return nil
+  end
+
   def self.uptime_string(delta)
     num_seconds = delta.to_i
     days = num_seconds / (60 * 60 * 24);

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -2,6 +2,7 @@
 base_dir: /var/vcap.local/dea
 local_route: 127.0.0.1
 filer_port: 12345
+#port_range: 34600..45000
 mbus: nats://localhost:4222/
 intervals:
   heartbeat: 10

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -86,6 +86,8 @@ module DEA
 
       @downloads_pending = {}
 
+      @port_range = process_range config['port_range'] if config['port_range']
+
       @shutting_down = false
 
       # Path to the ruby executable the dea should use when executing the prepare script.
@@ -131,6 +133,31 @@ module DEA
 
       # XXX(mjp) - Ugh, this is needed for VCAP::Component.register(). Find a better solution when time permits.
       @config = config.dup()
+    end
+
+    def process_range port_range
+      case port_range.count('.')
+         when 2     # we have an inclusive upper bound
+             ports = port_range.split('..')
+             Float(ports[0])  # ugly testing whether we have valid numbers
+             Float(ports[1])
+             if (ports[0].to_i <= ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
+               return Range.new(ports[0].to_i, ports[1].to_i)
+             end
+         when 3    # we have an exclusive upper bound
+             ports = port_range.split('...')
+             Float(ports[0])
+             Float(ports[1])
+             if (ports[0].to_i < ports[1].to_i and ports[0].to_i > 0)  # check whether the port range makes sense
+               return Range.new(ports[0].to_i, ports[1].to_i - 1)
+             end
+         end
+
+      return nil
+
+      # wrongly formatted number. return nil
+      rescue
+        return nil
     end
 
     def run()
@@ -557,7 +584,12 @@ module DEA
       end
 
       start_operation = proc do
-        port = VCAP.grab_ephemeral_port
+        # fallback variant in case we cannot get a port in the configured range: use an ephemeral port
+        if @port_range
+          port = VCAP.grab_port_in_range @port_range || VCAP.grab_ephemeral_port
+        else
+          port =  VCAP.grab_ephemeral_port
+        end
 
         @logger.debug('Completed download')
         @logger.info("Starting up instance #{instance[:log_id]} on port:#{port}")

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -86,7 +86,13 @@ module DEA
 
       @downloads_pending = {}
 
-      @port_range = process_range config['port_range'] if config['port_range']
+      if config['port_range']
+	@port_range = process_range config['port_range']
+	if (!@port_range)
+	  @logger.fatal("Invalid configuration for property 'port_range'. Ruby range expected, but was given: #{config['port_range']}")
+	  exit 1
+	end
+      end
 
       @shutting_down = false
 
@@ -586,7 +592,11 @@ module DEA
       start_operation = proc do
         # fallback variant in case we cannot get a port in the configured range: use an ephemeral port
         if @port_range
-          port = VCAP.grab_port_in_range @port_range || VCAP.grab_ephemeral_port
+          port = VCAP.grab_port_in_range @port_range
+	  if (!port) 
+	    @logger.fatal("Could not get a free port from the specified range: #{@port_range}")
+	    exit 1
+	  end
         else
           port =  VCAP.grab_ephemeral_port
         end

--- a/dea/spec/functional/agent_spec.rb
+++ b/dea/spec/functional/agent_spec.rb
@@ -50,6 +50,8 @@ describe 'DEA Agent' do
     }
     @nats_server = NatsComponent.new(@nats_cfg)
 
+    @free_port = VCAP.grab_ephemeral_port
+
     # DEA
     @dea_cfg = {
       'base_dir'     => @run_dir,
@@ -71,6 +73,7 @@ describe 'DEA Agent' do
         }
       },
       'disable_dir_cleanup' => true,
+      'port_range' => Range.new(@free_port, @free_port).to_s,
     }
     @dea_config_file = File.join(@run_dir, 'dea.config')
     File.open(@dea_config_file, 'w') {|f| YAML.dump(@dea_cfg, f) }
@@ -147,6 +150,16 @@ describe 'DEA Agent' do
       droplet_info["tags"].should == {"framework"=>"sinatra", "runtime"=>"ruby18"}
       droplet_info["uris"].should == ["test_app.vcap.me"]
     end
+
+    it 'should start a droplet on a particular port, when there is a singleton port range specified' do
+      droplet_info = start_droplet(@nats_server.uri, @droplet)
+      droplet_info.should_not be_nil
+      wait_for { port_open?(droplet_info['port']) }.should be_true
+      droplet_info["tags"].should == {"framework"=>"sinatra", "runtime"=>"ruby18"}
+      droplet_info["uris"].should == ["test_app.vcap.me"]
+      droplet_info['port'].should == @free_port
+    end
+
 
     it 'should heartbeat a running droplet' do
       droplet_info = start_droplet(@nats_server.uri, @droplet)


### PR DESCRIPTION
Currently, the DEA nodes use the ephemeral port range from the underlying OS, for picking up a port number to supply to each droplet. This range can be configured, and probably the network stack should be restarted for the change to take effect. 

This pull request provides a new configuration property for DEA nodes: port_range, which allows you to specify some range, in terms of Ruby range literal, that will be considered when choosing the port. DEA will try to pick up a random port within the range, which is free, if possible. If this fails, a fallback variant is applied, which is the default behaviour - using the ephemeral port range. This has the advantage that only the DEA must be restarted in order for the configuration change to take effect.

In a secured corporate setup, the allowed network ports are restricted and tightly controlled. Most administrators would require to be able to specify some port range, rather than having them randomly chosen.

Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
