### PR TITLE
Introducing support for internal SSL communication.

### DIFF
--- a/bin/cloud_controller
+++ b/bin/cloud_controller
@@ -58,10 +58,12 @@ if not CloudController.use_nginx
 else
   socket = CloudController.instance_socket
   port =   CloudController.instance_port
-  if socket and port
-    $stderr.puts "only one of instance_socket or insecure_instance_port should be enabled in config file...quiting..."
-    exit 1
-  end
+  # This limitation is a problem when there is a nginx server in front, and an SSL configuration.
+  # The socket is needed for the nginx communication, while the port is needed for CC external clients.
+  #if socket and port
+  #  $stderr.puts "only one of instance_socket or insecure_instance_port should be enabled in config file...quiting..."
+  #  exit 1
+  #end
   if socket
     server = Thin::Server.new(socket)
   else

--- a/cloud_controller/app/models/app_manager.rb
+++ b/cloud_controller/app/models/app_manager.rb
@@ -439,7 +439,12 @@ class AppManager
   end
 
   def download_app_uri(path)
-    ['http://', "#{CloudController.bind_address}:#{CloudController.external_port}", path].join
+    if AppConfig[:ssl]
+      scheme = 'https://'
+    else
+      scheme = 'http://'
+    end
+    [scheme, "#{CloudController.bind_address}:#{CloudController.external_port}", path].join
   end
 
   # start_instance involves several moving pieces, from sending requests for help to the

--- a/cloud_controller/config/boot.rb
+++ b/cloud_controller/config/boot.rb
@@ -64,7 +64,11 @@ module CloudController
     end
 
     def instance_port
-      AppConfig[:nginx][:insecure_instance_port]
+      if AppConfig[:ssl]
+         AppConfig[:ssl][:ssl_port]
+      else
+         AppConfig[:nginx][:insecure_instance_port]
+      end
     end
 
     def instance_socket

--- a/cloud_controller/config/cloud_controller.yml
+++ b/cloud_controller/config/cloud_controller.yml
@@ -18,6 +18,10 @@ app_uris:
 #  reserved_list: [www, test, dash, register, foo, bar]
 #  reserved_length: 3
 
+# This will make the internal communication go through SSL
+#ssl:
+#  ssl_port: 9022
+
 external_port: 9022 #public CC port
 
 #nginx proxy provide multiple functions including

--- a/cloud_controller/staging/java_web/plugin.rb
+++ b/cloud_controller/staging/java_web/plugin.rb
@@ -60,23 +60,7 @@ class JavaWebPlugin < StagingPlugin
       <<-JAVA
 export CATALINA_OPTS="$CATALINA_OPTS `ruby resources/set_environment`"
 env > env.log
-PORT=-1
-SSL="false"
-while getopts ":p:s" opt; do
-  case $opt in
-    p)
-      PORT=$OPTARG
-      ;;
-    s)
-      SSL="true"
-      ;;
-  esac
-done
-if [ $PORT -lt 0 ] ; then
-  echo "Missing or invalid port (-p)"
-  exit 1
-fi
-ruby resources/generate_server_xml $PORT $SSL
+ruby resources/generate_server_xml $BACKEND_PORT
       JAVA
     end
   end

--- a/cloud_controller/staging/java_web/plugin.rb
+++ b/cloud_controller/staging/java_web/plugin.rb
@@ -61,10 +61,14 @@ class JavaWebPlugin < StagingPlugin
 export CATALINA_OPTS="$CATALINA_OPTS `ruby resources/set_environment`"
 env > env.log
 PORT=-1
-while getopts ":p:" opt; do
+SSL="false"
+while getopts ":p:s" opt; do
   case $opt in
     p)
       PORT=$OPTARG
+      ;;
+    s)
+      SSL="true"
       ;;
   esac
 done
@@ -72,7 +76,7 @@ if [ $PORT -lt 0 ] ; then
   echo "Missing or invalid port (-p)"
   exit 1
 fi
-ruby resources/generate_server_xml $PORT
+ruby resources/generate_server_xml $PORT $SSL
       JAVA
     end
   end

--- a/cloud_controller/staging/java_web/resources/generate_server_xml
+++ b/cloud_controller/staging/java_web/resources/generate_server_xml
@@ -5,7 +5,6 @@
 
 tomcat_port = ARGV[0]
 exit 1 unless tomcat_port
-use_ssl = ARGV[1]
 
 require 'erb'
 OUTPUT_PATH = "tomcat/conf/server.xml"
@@ -41,20 +40,8 @@ TEMPLATE = <<-ERB
 
   <Service name="Catalina">
 
-    <% if use_ssl == "true"  %>
-
-       <Connector port="<%= tomcat_port %>" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               scheme="https" secure="true" SSLEnabled="true"
-               keystoreFile="conf/default.jks" keystorePass="cloudfoundry"
-               clientAuth="false" sslProtocol="TLS"/>
-
-    <% else %>
-
        <Connector port="<%= tomcat_port %>" protocol="HTTP/1.1"
                connectionTimeout="20000" />
-
-    <% end %>
 
     <Engine name="Catalina" defaultHost="localhost">
 

--- a/cloud_controller/staging/java_web/resources/generate_server_xml
+++ b/cloud_controller/staging/java_web/resources/generate_server_xml
@@ -5,6 +5,7 @@
 
 tomcat_port = ARGV[0]
 exit 1 unless tomcat_port
+use_ssl = ARGV[1]
 
 require 'erb'
 OUTPUT_PATH = "tomcat/conf/server.xml"
@@ -40,8 +41,20 @@ TEMPLATE = <<-ERB
 
   <Service name="Catalina">
 
-    <Connector port="<%= tomcat_port %>" protocol="HTTP/1.1"
+    <% if use_ssl == "true"  %>
+
+       <Connector port="<%= tomcat_port %>" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               scheme="https" secure="true" SSLEnabled="true"
+               keystoreFile="conf/default.jks" keystorePass="cloudfoundry"
+               clientAuth="false" sslProtocol="TLS"/>
+
+    <% else %>
+
+       <Connector port="<%= tomcat_port %>" protocol="HTTP/1.1"
                connectionTimeout="20000" />
+
+    <% end %>
 
     <Engine name="Catalina" defaultHost="localhost">
 

--- a/cloud_controller/staging/node/plugin.rb
+++ b/cloud_controller/staging/node/plugin.rb
@@ -7,6 +7,7 @@ class NodePlugin < StagingPlugin
 
   def stage_application
     Dir.chdir(destination_directory) do
+      FileUtils.cp_r(StagingPlugin.resource_dir, destination_directory)
       create_app_directories
       copy_source_files
       create_startup_script
@@ -15,7 +16,7 @@ class NodePlugin < StagingPlugin
 
   # Let DEA fill in as needed..
   def start_command
-    "%VCAP_LOCAL_RUNTIME% #{detect_main_file} $@"
+    "export VMC_APP_PORT=$BACKEND_PORT\n%VCAP_LOCAL_RUNTIME% #{detect_main_file} "
   end
 
   private

--- a/cloud_controller/staging/rails3/plugin.rb
+++ b/cloud_controller/staging/rails3/plugin.rb
@@ -13,9 +13,9 @@ class Rails3Plugin < StagingPlugin
     if uses_bundler?
       # Specify Thin if the app bundled it; otherwise let Rails figure it out.
       server_script = thin? ? "server thin" : "server"
-      "#{local_runtime} #{gem_bin_dir}/bundle exec #{local_runtime} #{gem_bin_dir}/rails #{server_script} $@"
+      "#{local_runtime} #{gem_bin_dir}/bundle exec #{local_runtime} #{gem_bin_dir}/rails #{server_script} -p $BACKEND_PORT"
     else
-      "#{local_runtime} -S thin -R config.ru $@ start"
+      "#{local_runtime} -S thin -R config.ru -p $BACKEND_PORT start"
     end
   end
 
@@ -34,6 +34,7 @@ class Rails3Plugin < StagingPlugin
 
   def stage_application
     Dir.chdir(destination_directory) do
+      FileUtils.cp_r(StagingPlugin.resource_dir, destination_directory)
       create_app_directories
       copy_source_files
       compile_gems

--- a/cloud_controller/staging/resources/generate_vhost_conf
+++ b/cloud_controller/staging/resources/generate_vhost_conf
@@ -1,0 +1,43 @@
+port = ARGV[0]
+backend_port = ARGV[1]
+droplet_name = ARGV[2]
+ssl_enabled = ARGV[3]
+exit 1 unless port and backend_port and droplet_name and ssl_enabled
+
+require 'erb'
+
+OUTPUT_PATH = "/etc/nginx/vhosts/#{droplet_name}.conf"
+
+TEMPLATE = <<-ERB
+server {
+    listen       <%= port %>;
+    server_name  _;
+
+    access_log   /var/vcap/sys/log/vcap.access.<%= droplet_name %>.<%= port %>.log main;
+    server_name_in_redirect off;
+
+<% if ssl_enabled == "true" %>
+    ssl on;
+    ssl_certificate /etc/nginx/cert/server.crt;
+    ssl_certificate_key /etc/nginx/cert/server.key;
+<% end %>
+
+    location / {
+        proxy_buffering                 off;
+        proxy_set_header                Host $host;
+        proxy_set_header                X-Real_IP $remote_addr;
+        proxy_set_header                X-Forwarded_For $proxy_add_x_forwarded_for;
+        proxy_set_header                X-Forwarded_Proto http;
+        proxy_redirect                  off;
+        proxy_connect_timeout           100;
+        proxy_send_timeout              300;
+        proxy_read_timeout              300;
+        proxy_pass                      http://localhost:<%= backend_port %>;
+    }
+}
+ERB
+
+template = ERB.new(TEMPLATE)
+File.open(File.expand_path(OUTPUT_PATH), 'wb') do |file|
+  file.puts(template.result(binding))
+end

--- a/cloud_controller/staging/sinatra/plugin.rb
+++ b/cloud_controller/staging/sinatra/plugin.rb
@@ -6,6 +6,7 @@ class SinatraPlugin < StagingPlugin
 
   def stage_application
     Dir.chdir(destination_directory) do
+      FileUtils.cp_r(StagingPlugin.resource_dir, destination_directory)
       create_app_directories
       copy_source_files
       compile_gems
@@ -18,9 +19,9 @@ class SinatraPlugin < StagingPlugin
   def start_command
     sinatra_main = detect_main_file
     if uses_bundler?
-      "#{local_runtime} ./rubygems/ruby/#{library_version}/bin/bundle exec #{local_runtime} ./#{sinatra_main} $@"
+      "#{local_runtime} ./rubygems/ruby/#{library_version}/bin/bundle exec #{local_runtime} ./#{sinatra_main} -p $BACKEND_PORT"
     else
-      "#{local_runtime} #{sinatra_main} $@"
+      "#{local_runtime} #{sinatra_main} -p $BACKEND_PORT"
     end
   end
 

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -13,6 +13,13 @@ secure: false
 enforce_ulimit: false
 pid: /var/vcap/sys/run/dea.pid
 
+# This will make SSL capable frameworks to use SSL
+# DEA will use these settings also for downloading droplets via HTTPS
+#ssl:
+#   private_key_file: '/tmp/cert/server.key'
+#   cert_chain_file: '/tmp/cert/server.crt'
+#   verify_peer: false
+
 #Force droplets to be downloaded over http even when
 #there is a shared directory containing the droplet.
 force_http_sharing: true

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -563,6 +563,7 @@ module DEA
 
       start_operation = proc do
         port = VCAP.grab_ephemeral_port
+        backend_port = VCAP.grab_ephemeral_port
 
         @logger.debug('Completed download')
         @logger.info("Starting up instance #{instance[:log_id]} on port:#{port}")
@@ -626,7 +627,7 @@ module DEA
           end
           app_env.each { |env| process.send_data("export #{env}\n") }
 
-          prepare_command = "#{@dea_ruby} ./prepare true ./startup -p #{port}"
+          prepare_command = "#{@dea_ruby} ./prepare true ./startup -p #{port} -b #{backend_port}"
 
           if @enable_ssl
             prepare_command += " -s"

--- a/router/config/router.yml
+++ b/router/config/router.yml
@@ -5,3 +5,9 @@ mbus: nats://localhost:4222
 logging:
   level: info
 pid: /var/vcap/sys/run/router.pid
+
+# This will force the router to reencrypt the traffic to services, cc, dea, etc.
+#ssl:
+#   private_key_file: '/etc/nginx/cert/server.key'
+#   cert_chain_file: '/etc/nginx/cert/server.crt'
+#   verify_peer: false

--- a/router/lib/router/client_connection.rb
+++ b/router/lib/router/client_connection.rb
@@ -163,6 +163,11 @@ module ClientConnection
     else
       host, port = @droplet[:host], @droplet[:port]
       @bound_app_conn = EM.connect(host, port, AppConnection, self, @headers, @droplet)
+
+      if (Router.ssl_opts)
+          @bound_app_conn.start_tls Router.ssl_opts
+      end
+       
     end
 
   end

--- a/router/lib/router/router.rb
+++ b/router/lib/router/router.rb
@@ -4,7 +4,7 @@ class Router
   VERSION = 0.98
 
   class << self
-    attr_reader   :log, :notfound_redirect, :session_key, :trace_key
+    attr_reader   :log, :notfound_redirect, :session_key, :trace_key, :ssl_opts
     attr_accessor :server, :local_server, :timestamp, :shutting_down
     attr_accessor :client_connection_count, :app_connection_count, :outstanding_request_count
     attr_accessor :inet, :port
@@ -27,6 +27,7 @@ class Router
 
       @session_key = config['session_key'] || '14fbc303b76bacd1e0a3ab641c11d11400341c5d'
       @trace_key = config['trace_key'] || '22'
+      @ssl_opts = config['ssl']
     end
 
     def setup_listeners


### PR DESCRIPTION
Secured corporate landscapes may require that communication traffic be encrypted. So we have prepared a change, which makes internal traffic go over SSL, where appropriate. For these purposes:
- suitable SSL certificates must be generated and provided as new configuration properties
- a java keystore file must be provided inside tomcat/conf. We have included a simple and dummy one
- an HTTPS connector in Tomcat must be enabled. The keystore password is "cloudfoundry".
- the nginx servers must be recompiled against the OpenSSL library, and several other nginx modules/plugins.
- we have adopted the strategy of using a nginx server in front of the cloud controller, having opened both plain HTTP and HTTPS servers.

Note: This change is relevant for Tomcat-powered applications only.

Important: Detailed user guide documentation for this change can be found here: https://github.com/cloudfoundry-collaboration/vcap/wiki/Setup-internal-SSL-communicationDear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
