### PR TITLE
Ensure custom config is picked up in vcap script's db:migrate when using custom config location

### DIFF
--- a/bin/vcap
+++ b/bin/vcap
@@ -136,7 +136,7 @@ class Component
         # Make sure db is setup, this is slow and we should make it faster, but
         # should help for now.
         if is_cloud_controller?
-          Dir.chdir("#{File.dirname(__FILE__)}/../cloud_controller") { `rake db:migrate` }
+          Dir.chdir("#{File.dirname(__FILE__)}/../cloud_controller") { `rake db:migrate CLOUD_CONTROLLER_CONFIG=#{@configuration_path}` }
         end
         exec("#{component_start_path}")
       end
@@ -422,7 +422,14 @@ module Run
     args = (Run.core + Run.services) if args.empty?
     args = Run.expand_args(args)
     components = args.map do |arg|
-      component = Component.new(arg)
+      if $configdir
+        config_file = File.join($configdir, "#{arg}.yml")
+        puts config_file
+        if ! File.exists?(config_file)
+          config_file = nil
+        end
+      end
+      component = Component.new(arg, config_file)
       component if component.exists?
     end.compact
     STDERR.puts "Don't know how to process '#{args.inspect}' \?\?" if components.empty?

--- a/bin/vcap
+++ b/bin/vcap
@@ -424,7 +424,6 @@ module Run
     components = args.map do |arg|
       if $configdir
         config_file = File.join($configdir, "#{arg}.yml")
-        puts config_file
         if ! File.exists?(config_file)
           config_file = nil
         end


### PR DESCRIPTION
When you use a custom config location for vcap (using the -c flag to bin/vcap), the "rake db:migrate" script called in the vcap script doesn't look at the correct config file to determine the database configuration. Instead, it looks at the config file in the default location. The result is that you can have a situation where you start up cloud_controller and it won't have its database set up.

This patch fixes this, but I recognize that there might be a better solution. I'm open to suggestions.
