### PR TITLE
Add optional profile.sh file to ease deployment

### DIFF
--- a/dev_setup/cookbooks/essentials/recipes/default.rb
+++ b/dev_setup/cookbooks/essentials/recipes/default.rb
@@ -13,3 +13,11 @@
     action [:install]
   end
 end
+
+if node[:deployment][:profile]
+  file node[:deployment][:profile] do
+    owner node[:deployment][:user]
+    group node[:deployment][:group]
+    content "export PATH=#{node[:ruby][:path]}/bin:`#{node[:ruby][:path]}/bin/gem env gempath`/bin:$PATH"
+  end
+end


### PR DESCRIPTION
This commit allows you to create a profile.sh file you can source to make deployment easier with the chef recipes. The goal is to make it simpler to have access to vmc and the vcap command in your environment. 

This patch doesn't provide a location for it by default, but one option is to put the file in /etc/profile.d/ so you have vmc in your env by default, and running /var/vcap/bin/vcap will just work. Another option is to put it in a home directory so you can manually source it.

Anyway, no default is set in this patch, and if you want to specify where the file should go, just set node[:deployment][:profile] in your chef env.
