### PR TITLE
fixed a bug in php implementation that does not stop apache processes pro

### DIFF
--- a/cloud_controller/staging/common.rb
+++ b/cloud_controller/staging/common.rb
@@ -293,6 +293,10 @@ class StagingPlugin
     app_server['executable']
   end
 
+  #interface to kill_additional_processes
+  def kill_additional_processes
+  end
+
   def local_runtime
     '%VCAP_LOCAL_RUNTIME%'
   end
@@ -392,6 +396,7 @@ echo "$STARTED" >> ../run.pid
 echo "#!/bin/bash" >> ../stop
 echo "kill -9 $STARTED" >> ../stop
 echo "kill -9 $PPID" >> ../stop
+<%= kill_additional_processes %>
 chmod 755 ../stop
 wait $STARTED
     SCRIPT

--- a/cloud_controller/staging/php/plugin.rb
+++ b/cloud_controller/staging/php/plugin.rb
@@ -28,6 +28,19 @@ class PhpPlugin < StagingPlugin
     "bash ./start.sh"
   end
 
+  def kill_additional_processes
+<<-ADDITION
+export instance_id=`cat ../env.log |grep HOME|awk -F"/" '{print $6}'`
+echo $instance_id > ../inst.log
+sleep 50
+for id in `ps aux | grep $instance_id | awk '{print $2}'`; do
+    echo $id >> ../inst.log
+    echo "kill -9 $id" >> ../stop
+done
+ADDITION
+  end
+
+
   private
 
   def startup_script


### PR DESCRIPTION
fixed a bug in php implementation that does not stop apache processes properly

The startup script in PHP implementation launch an apache instance, after that, the apache instance will spawn 5 more child apache instances. However, the stop script does not catch those, not even the first apache process. As the result, when "vmc stop [appname]" request is sent, all apache instances remain running even though the app is "stopped".

The fix is trying to catch all apache instances and put them into stop script so that when "vmc stop [appname]" command is issued, all apache instances associated with the app will be killed.
