### PR TITLE
enable remote java web application debugging

### DIFF
--- a/cloud_controller/staging/common.rb
+++ b/cloud_controller/staging/common.rb
@@ -293,6 +293,10 @@ class StagingPlugin
     app_server['executable']
   end
 
+  def debug_options
+    #interface for debugging options
+  end
+
   def local_runtime
     '%VCAP_LOCAL_RUNTIME%'
   end
@@ -383,6 +387,7 @@ class StagingPlugin
     after_env_before_script = block_given? ? yield : "\n"
     template = <<-SCRIPT
 #!/bin/bash
+<%= debug_options %>
 <%= environment_statements_for(env_vars) %>
 <%= after_env_before_script %>
 <%= change_directory_for_start %>

--- a/cloud_controller/staging/java_web/plugin.rb
+++ b/cloud_controller/staging/java_web/plugin.rb
@@ -44,13 +44,30 @@ class JavaWebPlugin < StagingPlugin
   # We redefine this here because Tomcat doesn't want to be passed the cmdline
   # args that were given to the 'start' script.
   def start_command
-    "./bin/catalina.sh run"
+    "./bin/catalina.sh $my_jpda run"
   end
 
   def configure_catalina_opts
     # We want to set this to what the user requests, *not* set a minum bar
-    "-Xms#{application_memory}m -Xmx#{application_memory}m"
+    "-Xms#{application_memory}m -Xmx#{application_memory}m  $my_verbose"
   end
+
+  # redefine debugging options, only works for java app
+  def debug_options
+    <<-SCRIPT
+my_jpda=""
+my_verbose=""
+if [ -n "${JPDA+x}" ]; then
+   my_jpda="jpda"
+   my_verbose="-verbose"
+fi
+EXPORT my_jpda
+EXPORT my_verbose
+echo "debug flag : $my_jpda, $my_verbose and JPDA=$JPDA" >debug.log       
+    SCRIPT
+  end
+
+
 
   private
   def startup_script

--- a/cloud_controller/staging/java_web/resources/set_environment
+++ b/cloud_controller/staging/java_web/resources/set_environment
@@ -12,4 +12,15 @@ env = []
     env << "-D#{protocol}.proxyHost=#{uri.host} -D#{protocol}.proxyPort=#{uri.port}"
   end
 end
+
+#debug settins for java debugging
+jpda = ENV['JPDA']
+if jpda
+   {'JPDA_TRANSPORT' => 'dt_socket', 'JPDA_ADDRESS' => '8000', 'JPDA_SUSPEND' => 'n'}.each do |env_var, env_val|
+       ipda_opts = ENV[env_var]
+       ipda_opts = env_val unless ipda_opts
+       env << "-D#{env_var}=#{ipda_opts}"
+   end
+end
+
 puts env.join(' ')

--- a/docs/java_debugging.md
+++ b/docs/java_debugging.md
@@ -1,0 +1,21 @@
+Instruction on how to enable remote debugging on Java application:
+
+1. Setup Java app for remote debugging with Cloud Foundry
+
+1) Deploy your Java web application as normal vmc push process
+2) Stop the application running "vmc stop [appname]"
+3) Run "vmc env-add [appname] JPDA=1". This will enable debugging for the Java application
+4) You have choice to set the port number for debugging by running
+       vmc env-add [appname] JPDA_ADDRESS=8080
+5) Restart the application by running "vmc start [appname]". You are ready to debug your application.
+
+2. Clean-up after remote debugging
+
+You need to remove the environment variables that you set for remote debugging.
+
+1)    Run "vmc env [appname]" to lookup all environment variables that you set
+2)    Stop your app by running "vmc stop [appname]"
+3)    Remove JPDA variable by "vmc env-del [appname] JPDA"
+4)    Remove JPDA_ADDRESS by running "vmc env-del [appname] JPDA_ADDRESS"
+5)    Restart your application by running "vmc start [appname]".
+


### PR DESCRIPTION
This feature is to enable remote java web application debugging. It has been tested and verified. A wiki page has been created to show how to use the feature.
