### PR TITLE
[PATCH] UserTokensController#create should support admin privilege.

### DIFF
--- a/cloud_controller/app/controllers/user_tokens_controller.rb
+++ b/cloud_controller/app/controllers/user_tokens_controller.rb
@@ -1,10 +1,9 @@
 class UserTokensController < ApplicationController
-  skip_before_filter :fetch_user_from_token, :only => :create
 
   def create
     email = params['email']
     password = body_params[:password]
-    if ::User.valid_login?(email, password)
+    if ::User.valid_login?(email, password) || (@current_user && @current_user.admin?)
       # This could just check the ::User.admins variable, but using this method to support changes in admin? in the future
       user = ::User.find_by_email(email)
       if AppConfig[:https_required] or (user.admin? and AppConfig[:https_required_for_admins])

--- a/cloud_controller/spec/requests/user_tokens_spec.rb
+++ b/cloud_controller/spec/requests/user_tokens_spec.rb
@@ -14,6 +14,12 @@ describe "Requesting a new user token" do
     response.status.should == 400
   end
 
+  it "always returns a 200 response when admin requests" do
+    post @user_token_path, nil, headers_for(@admin.email, nil, '{}')
+    response.status.should == 200
+  end
+
+
   # This code tests https enforcement in a variety of scenarios defined in cloud_spec_helpers.rb
   CloudSpecHelpers::HTTPS_ENFORCEMENT_SCENARIOS.each do |scenario_vars|
     describe "#{scenario_vars[:appconfig_enabled].empty? ? '' : 'with ' + (scenario_vars[:appconfig_enabled].map{|x| x.to_s}.join(', ')) + ' enabled'} using #{scenario_vars[:protocol]}" do


### PR DESCRIPTION
Hi,

This change make it enabled that password validation is skipped
and a token is always generated when a admin requests the endpoint.

currently we build authentication proxy as following and an issue remains:

vmc client --> AuthProxy --> CloudController.

when 'vmc loign' is issued, AuthProxy validates the credentials with our original authentication source and generates a token instead of CloudController. AuthProxy creates a user automatically when the first login ends successfully and it forgets the generated password.

But in this implementation, a token needs to be validated everytime in AuthProxy and it needs issued tokens somewhere (in RDB or KVS or FileSystem). This is a cost for managing the token storage in AuthProxy and we should avoid it.
