### PR TITLE
Make expiration of user token configuable

### DIFF
--- a/cloud_controller/Gemfile
+++ b/cloud_controller/Gemfile
@@ -54,5 +54,6 @@ group :test do
   gem 'mocha'
   gem 'ci_reporter'
   gem 'sinatra'  # For service gateway shims
+  gem 'delorean'
 end
 

--- a/cloud_controller/Gemfile.lock
+++ b/cloud_controller/Gemfile.lock
@@ -44,9 +44,12 @@ GEM
     arel (2.0.9)
     bcrypt-ruby (2.1.4)
     builder (2.1.2)
+    chronic (0.6.4)
     ci_reporter (1.6.4)
       builder (>= 2.1.2)
     daemons (1.1.2)
+    delorean (1.1.0)
+      chronic
     diff-lcs (1.1.2)
     em-http-request (1.0.0.beta.3)
       addressable (>= 2.2.3)
@@ -142,6 +145,7 @@ DEPENDENCIES
   SystemTimer
   bcrypt-ruby (>= 2.1.4)
   ci_reporter
+  delorean
   em-http-request (~> 1.0.0.beta.3)
   em-redis
   eventmachine (~> 0.12.10)

--- a/cloud_controller/app/models/user_token.rb
+++ b/cloud_controller/app/models/user_token.rb
@@ -3,10 +3,10 @@ require 'hmac-sha1'
 class UserToken
   class DecodeError < ArgumentError;end
   class << self
-    attr_accessor :token_key
+    attr_accessor :token_key, :token_expire
 
     def create(user_name)
-      valid_until = (Time.now.utc + 1.week).to_i
+      valid_until = (Time.now.utc + token_expire).to_i
       new(user_name, valid_until)
     end
 
@@ -23,6 +23,10 @@ class UserToken
     def hmac(*strings)
       key = UserToken.token_key
       HMAC::SHA1.new(key).update(strings.join).digest
+    end
+
+    def token_expire
+      @token_expire ||= 1.week
     end
   end
   attr_reader :user_name, :valid_until, :hmac

--- a/cloud_controller/config/cloud_controller.yml
+++ b/cloud_controller/config/cloud_controller.yml
@@ -62,6 +62,8 @@ mbus: nats://localhost:4222/
 keys:
   password: 'password key goes here'
   token: 'token key goes here'
+expiration:
+  token: 604800 # 7 * 24 * 60 * 60 (= 1 week)
 pid: /var/vcap/sys/run/cloudcontroller.pid
 rails_environment: development
 database_environment: # replaces database.yml

--- a/cloud_controller/config/initializers/user_tokens.rb
+++ b/cloud_controller/config/initializers/user_tokens.rb
@@ -1,3 +1,4 @@
 require 'user_token'
 UserToken.token_key = AppConfig[:keys][:token].dup
+UserToken.token_expire = AppConfig[:expiration][:token]
 

--- a/cloud_controller/spec/models/user_token_spec.rb
+++ b/cloud_controller/spec/models/user_token_spec.rb
@@ -63,11 +63,11 @@ describe UserToken do
 
   context "When expiration days is specified" do
     before do
-      UserToken.expire = 1.day
+      UserToken.token_expire = 1.day
     end
     it "token should be expired if it goes over the expired date." do
       token = nil
-      Delorean.time_travel_to("1 day ago") do
+      Delorean.time_travel_to("25 hours ago") do
         token = UserToken.create('expire@example.com')
       end 
       token.should be_expired

--- a/cloud_controller/spec/models/user_token_spec.rb
+++ b/cloud_controller/spec/models/user_token_spec.rb
@@ -60,5 +60,18 @@ describe UserToken do
       hmac.should be_kind_of(String)
     end
   end
+
+  context "When expiration days is specified" do
+    before do
+      UserToken.expire = 1.day
+    end
+    it "token should be expired if it goes over the expired date." do
+      token = nil
+      Delorean.time_travel_to("1 day ago") do
+        token = UserToken.create('expire@example.com')
+      end 
+      token.should be_expired
+    end
+  end
 end
 

--- a/cloud_controller/spec/requests/user_tokens_spec.rb
+++ b/cloud_controller/spec/requests/user_tokens_spec.rb
@@ -14,6 +14,48 @@ describe "Requesting a new user token" do
     response.status.should == 400
   end
 
+  context "When user_expire is specified" do
+    before { UserToken.token_expire = 1.day }
+    let :token do
+      json = Yajl::Parser.parse(response.body)
+      token = UserToken.decode(json['token'])
+    end
+
+    context "and a token was published 25 hours ago" do
+      before do
+        Delorean.time_travel_to "25 hours ago" do
+          post @user_token_path, {"password" => @user_password}.to_json, {'X-Forwarded_Proto' => 'http'}
+        end
+      end
+      it "should return a 200 response" do 
+        response.should be_ok
+      end
+      it "a given token should be expired" do
+        token.should be_expired
+      end
+      it "a given token should not be valid since it's expired." do
+        token.should_not be_valid
+      end
+    end
+
+    context "and a token was published within 1 day" do
+      before do
+        Delorean.time_travel_to "23 hours ago" do
+          post @user_token_path, {"password" => @user_password}.to_json, {'X-Forwarded_Proto' => 'http'}
+        end
+      end
+      it "should return a 200 response" do
+        response.should be_ok
+      end
+      it "a given token should not be expired" do
+        token.should_not be_expired
+      end
+      it "a given token should be valid." do
+        token.should be_valid
+      end
+    end
+  end
+
   # This code tests https enforcement in a variety of scenarios defined in cloud_spec_helpers.rb
   CloudSpecHelpers::HTTPS_ENFORCEMENT_SCENARIOS.each do |scenario_vars|
     describe "#{scenario_vars[:appconfig_enabled].empty? ? '' : 'with ' + (scenario_vars[:appconfig_enabled].map{|x| x.to_s}.join(', ')) + ' enabled'} using #{scenario_vars[:protocol]}" do


### PR DESCRIPTION
This changes make the expiration of user token configurable. 
The expiration is directly hard-coded as 1 week and UserToken model has no interface to change its expiration so far. 
So, I've implemented the interface and made it configurable by cloud_foundly.yml as follows: 

> ```
> keys:
>   password: 'password key goes here'
>   token: 'token key goes here'
> expiration: #  Here! 
>    token: 604800 #  7 * 24 * 60 * 60 (= 1 week)
> pid: /var/vcap/sys/run/cloudcontroller.pid
> rails_environment: development
> ```
