### PR TITLE
Expose requests-per-second for all apps not only top10

### DIFF
--- a/router/lib/router/router.rb
+++ b/router/lib/router/router.rb
@@ -87,8 +87,11 @@ class Router
         end
       end
 
-      top_10 = apps.sort { |a,b| b[:rps]<=>a[:rps] } [0,9]
-      VCAP::Component.varz[:top_app_requests] = top_10
+      top = apps.sort { |a,b| b[:rps]<=>a[:rps] }
+      VCAP::Component.varz[:top_app_requests]  = top
+      VCAP::Component.varz[:top10_app_requests]  = top[0,9]
+      #top_10 = apps.sort { |a,b| b[:rps]<=>a[:rps] } [0,9]
+      #VCAP::Component.varz[:top_app_requests] = top_10
       #log.debug "Calculated all request rates in  #{Time.now - now} secs."
     end
 

--- a/router/lib/router/router.rb
+++ b/router/lib/router/router.rb
@@ -90,9 +90,7 @@ class Router
       top = apps.sort { |a,b| b[:rps]<=>a[:rps] }
       VCAP::Component.varz[:top_app_requests]  = top
       VCAP::Component.varz[:top10_app_requests]  = top[0,9]
-      #top_10 = apps.sort { |a,b| b[:rps]<=>a[:rps] } [0,9]
-      #VCAP::Component.varz[:top_app_requests] = top_10
-      #log.debug "Calculated all request rates in  #{Time.now - now} secs."
+      log.debug "Calculated all request rates in  #{Time.now - now} secs."
     end
 
     def check_registered_urls


### PR DESCRIPTION
expose requests-per-second for all apps not only top 10 (top10 is preserved) in /vars status of router
