### PR TITLE
Fix passing params to status server

### DIFF
--- a/cloud_controller/config/cloud_controller.yml
+++ b/cloud_controller/config/cloud_controller.yml
@@ -141,3 +141,8 @@ runtimes:
     version: ".* 5.8.3"
   python26:
     version: 2.6.5
+
+status:
+  port: 34500
+  user: thin
+  password: thin

--- a/cloud_controller/config/cloud_controller.yml
+++ b/cloud_controller/config/cloud_controller.yml
@@ -142,7 +142,10 @@ runtimes:
   python26:
     version: 2.6.5
 
-status:
-  port: 34500
-  user: thin
-  password: thin
+# Used for /healthz and /vars endpoints. If not provided random
+# values will be generated on component start. Uncomment to use 
+# static values.
+#status:
+#  port: 34500
+#  user: thin
+#  password: thin

--- a/cloud_controller/config/final_stage/message_bus.rb
+++ b/cloud_controller/config/final_stage/message_bus.rb
@@ -32,9 +32,15 @@ end
 
 EM.next_tick do
   NATS.start(:uri => AppConfig[:mbus]) do
-    options = {:type => 'CloudController', :config => AppConfig, :index => AppConfig[:index]}
-    options[:host] = CloudController.bind_address
-    VCAP::Component.register(options)
+    status_config = AppConfig[:status] || {}
+    VCAP::Component.register(:type => 'CloudController',
+                           :host => CloudController.bind_address,
+                           :index => AppConfig[:index],
+                           :config => AppConfig,
+                           :port => status_config[:port],
+                           :user => status_config[:user],
+                           :password => status_config[:password])
+
     require File.join(File.expand_path('..', __FILE__), 'varz')
     files = Dir.glob(Rails.root.join('app','subscriptions','*.rb'))
     files.each { |fn| require(fn) }

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -83,3 +83,8 @@ runtimes:
     version: 2.6.5
     version_flag: '--version'
     environment:
+
+status:
+  port: 34501
+  user: thin
+  password: thin

--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -84,7 +84,10 @@ runtimes:
     version_flag: '--version'
     environment:
 
-status:
-  port: 34501
-  user: thin
-  password: thin
+# Used for /healthz and /vars endpoints. If not provided random
+# values will be generated on component start. Uncomment to use 
+# static values.
+#status:
+#  port: 34501
+#  user: thin
+#  password: thin

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -222,7 +222,14 @@ module DEA
       NATS.start(:uri => @nats_uri) do
 
         # Register ourselves with the system
-        VCAP::Component.register(:type => 'DEA', :host => @local_ip, :config => @config, :index => @config['index'])
+        status_config = @config['status']
+        VCAP::Component.register(:type => 'DEA',
+                           :host => @local_ip,
+                           :index => @config['index'],
+                           :config => @config,
+                           :port => status_config['port'],
+                           :user => status_config['user'],
+                           :password => status_config['password'])
 
         uuid = VCAP::Component.uuid
 

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -222,7 +222,7 @@ module DEA
       NATS.start(:uri => @nats_uri) do
 
         # Register ourselves with the system
-        status_config = @config['status']
+        status_config = @config['status'] || {}
         VCAP::Component.register(:type => 'DEA',
                            :host => @local_ip,
                            :index => @config['index'],

--- a/health_manager/config/health_manager.yml
+++ b/health_manager/config/health_manager.yml
@@ -51,3 +51,8 @@ intervals:
   # Time to wait before analyzing the state of an application that has been
   # started/restarted
   stable_state:         60
+
+status:
+  port: 34502
+  user: thin
+  password: thin

--- a/health_manager/config/health_manager.yml
+++ b/health_manager/config/health_manager.yml
@@ -52,7 +52,10 @@ intervals:
   # started/restarted
   stable_state:         60
 
-status:
-  port: 34502
-  user: thin
-  password: thin
+# Used for /healthz and /vars endpoints. If not provided random
+# values will be generated on component start. Uncomment to use 
+# static values.
+#status:
+#  port: 34502
+#  user: thin
+#  password: thin

--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -680,7 +680,7 @@ class HealthManager
   end
 
   def register_as_component
-    status_config = @config['status']
+    status_config = @config['status'] || {}
     VCAP::Component.register(:type => 'HealthManager',
                              :host => VCAP.local_ip(@config['local_route']),
                              :index => @config['index'],

--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -680,10 +680,14 @@ class HealthManager
   end
 
   def register_as_component
+    status_config = @config['status']
     VCAP::Component.register(:type => 'HealthManager',
                              :host => VCAP.local_ip(@config['local_route']),
                              :index => @config['index'],
-                             :config => @config)
+                             :config => @config,
+                             :port => status_config['port'],
+                             :user => status_config['user'],
+                             :password => status_config['password'])
 
     # Initialize VCAP component varzs..
     VCAP::Component.varz[:total_apps] = 0

--- a/router/config/router.yml
+++ b/router/config/router.yml
@@ -8,3 +8,8 @@ mbus: nats://localhost:4222
 logging:
   level: info
 pid: /var/vcap/sys/run/router.pid
+
+status:
+  port: 34503
+  user: thin
+  password: thin

--- a/router/config/router.yml
+++ b/router/config/router.yml
@@ -9,7 +9,10 @@ logging:
   level: info
 pid: /var/vcap/sys/run/router.pid
 
-status:
-  port: 34503
-  user: thin
-  password: thin
+# Used for /healthz and /vars endpoints. If not provided random
+# values will be generated on component start. Uncomment to use 
+# static values.
+#status:
+#  port: 34503
+#  user: thin
+#  password: thin


### PR DESCRIPTION
Pass configuration section "status" as status thin server parameters. Fixes bug with Component register method which expects port, username and password as options, but these values are not read from config file and not passed. No it takes section "status" from yaml config and passes it to Component.register(options)
