### PR TITLE
Expose requests-per-second for all apps not only top10

### DIFF
--- a/router/config/router.yml
+++ b/router/config/router.yml
@@ -8,3 +8,9 @@ mbus: nats://localhost:4222
 logging:
   level: info
 pid: /var/vcap/sys/run/router.pid
+
+# Config for /varz and /healthz endpoints
+#status:
+#  Uncomment and set true to show requests-per-second stats for all aps not only top 10. If not specified or set false only 10 apps are shown
+#  expose_all_apps: true
+

--- a/router/lib/router/router.rb
+++ b/router/lib/router/router.rb
@@ -27,6 +27,7 @@ class Router
 
       @session_key = config['session_key'] || '14fbc303b76bacd1e0a3ab641c11d11400341c5d'
       @trace_key = config['trace_key'] || '22'
+      @expose_all_apps = config['status']['expose_all_apps'] if config['status']
     end
 
     def setup_listeners
@@ -87,8 +88,9 @@ class Router
         end
       end
 
-      top_10 = apps.sort { |a,b| b[:rps]<=>a[:rps] } [0,9]
-      VCAP::Component.varz[:top_app_requests] = top_10
+      top = apps.sort { |a,b| b[:rps]<=>a[:rps] }
+      VCAP::Component.varz[:top_app_requests]  = top if @expose_all_apps
+      VCAP::Component.varz[:top10_app_requests]  = top[0,9]
       #log.debug "Calculated all request rates in  #{Time.now - now} secs."
     end
 


### PR DESCRIPTION
If config parameter expose_all_apps is supplied and equals to true request-per-second stats for all apps is exposed in /varz. Top 10 is preserved in any case.
