### PR TITLE
Run rake of the version specified in Gemfile.lock of Cloud Controller

### DIFF
--- a/bin/vcap
+++ b/bin/vcap
@@ -136,7 +136,23 @@ class Component
         # Make sure db is setup, this is slow and we should make it faster, but
         # should help for now.
         if is_cloud_controller?
-          Dir.chdir("#{File.dirname(__FILE__)}/../cloud_controller") { `rake db:migrate` }
+          gemlock_file = File.expand_path(
+            File.join('..', 'cloud_controller', 'Gemfile.lock'),
+            File.dirname(__FILE__))
+
+          version = nil
+          File.open(gemlock_file, "r") do |f|
+            f.each_line do |line|
+              if line =~ /\A\s*rake\s\((\d{1}\.\d{1}\.\d{1})\)/u
+                version = $1
+              end
+            end
+          end
+          
+          rake_command = 'rake'
+          rake_command += " _#{version}_" if version
+          rake_command += " db:migrate"
+          Dir.chdir("#{File.dirname(__FILE__)}/../cloud_controller") { `#{rake_command}` }
         end
         exec("#{component_start_path}")
       end


### PR DESCRIPTION
In the enviroment which has a various versions of rake,  launch cloud controller then 

```
    [cloudfoundry/vcap] ./bin/vcap tail cloud_controller 
    cloud_controller --> rake aborted!
    cloud_controller --> You have already activated rake 0.9.2, but your Gemfile requires rake 0.8.7. Consider using bundle exec.
```

At the first time to launch CC, db migration will abort. 

In this modification, vcap command uses rake of the version specified in Gemfile.lock of CC. 
