### PR TITLE
Health manager specs

### DIFF
--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -429,11 +429,13 @@ class HealthManager
 
   def process_heartbeat_message(message)
     VCAP::Component.varz[:heartbeat_msgs_received] += 1
+    result = []
     parse_json(message)['droplets'].each do |heartbeat|
       droplet_id = heartbeat['droplet']
       instance = heartbeat['instance']
       droplet_entry = @droplets[droplet_id]
       if droplet_entry
+        result << droplet_entry
         state = heartbeat['state']
         if RUNNING_STATES.include?(state)
           version_entry = droplet_entry[:versions][heartbeat['version']]
@@ -471,6 +473,8 @@ class HealthManager
         end
       end
     end
+
+    result # return the droplets that we changed. This allows the spec tests to ensure the behaviour is correct.
   end
 
   def process_health_message(message, reply)

--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -425,6 +425,8 @@ class HealthManager
         }
       end
     end
+
+    droplet_entry # return the droplet that we changed. This allows the spec tests to ensure the behaviour is correct.
   end
 
   def process_heartbeat_message(message)

--- a/health_manager/spec/health_manager_spec.rb
+++ b/health_manager/spec/health_manager_spec.rb
@@ -57,11 +57,11 @@ describe HealthManager do
     @hm = HealthManager.new({
       'mbus' => 'nats://localhost:4222/',
       'logging' => {
-        'level' => 'fatal',
+        'level' => 'warn',
       },
       'intervals' => {
         'database_scan' => 1,
-        'droplet_lost' => 3,
+        'droplet_lost' => 300,
         'droplets_analysis' => 0.5,
         'flapping_death' => 3,
         'flapping_timeout' => 5,
@@ -149,5 +149,29 @@ describe HealthManager do
     stats[:down].should == 3
     stats[:frameworks]['sinatra'][:missing_instances].should == 3
     stats[:runtimes]['ruby19'][:missing_instances].should == 3
+  end
+
+  it "should detect extra instances and send a STOP request" do
+    stats = { :frameworks => {}, :runtimes => {}, :running => 0, :down => 0 }
+    timestamp = Time.now.to_i
+    version_entry = { indices: {
+        0 => { :state => 'RUNNING', :timestamp => timestamp, :last_action => @app.last_updated, :instance => '0' },
+        1 => { :state => 'RUNNING', :timestamp => timestamp, :last_action => @app.last_updated, :instance => '1' },
+        2 => { :state => 'RUNNING', :timestamp => timestamp, :last_action => @app.last_updated, :instance => '2' },
+        3 => { :state => 'RUNNING', :timestamp => timestamp, :last_action => @app.last_updated, :instance => '3' }
+    }}
+    should_publish_to_nats "cloudcontrollers.hm.requests", {
+          'droplet' => 1,
+          'op' => 'STOP',
+          'last_updated' => @app.last_updated.to_i,
+          'instances' => [ version_entry[:indices][3][:instance] ]
+        }
+    @droplet_entry[:versions][@droplet_entry[:live_version]] = version_entry
+
+    @hm.analyze_app(@app.id, @droplet_entry, stats)
+
+    stats[:running].should == 3
+    stats[:frameworks]['sinatra'][:running_instances].should == 3
+    stats[:runtimes]['ruby19'][:running_instances].should == 3
   end
 end

--- a/health_manager/spec/health_manager_spec.rb
+++ b/health_manager/spec/health_manager_spec.rb
@@ -174,4 +174,23 @@ describe HealthManager do
     stats[:frameworks]['sinatra'][:running_instances].should == 3
     stats[:runtimes]['ruby19'][:running_instances].should == 3
   end
+
+  it "should update its internal state to reflect heartbeat messages" do
+    droplet = {
+        'droplet' => @app.id, 'index' => 0, 'instance' => 0, 'state' => 'RUNNING',
+        'version' => @droplet_entry[:live_version], 'state_timestamp' => @droplet_entry[:last_updated]
+    }
+    message = { 'droplets' => [droplet] }
+
+    droplet_entries = @hm.process_heartbeat_message(message.to_json)
+
+    droplet_entries.size.should == 1
+    droplet_entry = droplet_entries[0]
+    droplet_entry[:versions].should_not be_nil
+    version_entry = droplet_entry[:versions][@droplet_entry[:live_version]]
+    version_entry.should_not be_nil
+    index_entry = version_entry[:indices][0]
+    index_entry.should_not be_nil
+    index_entry[:state].should == 'RUNNING'
+  end
 end

--- a/health_manager/spec/health_manager_spec.rb
+++ b/health_manager/spec/health_manager_spec.rb
@@ -31,6 +31,21 @@ describe HealthManager do
       @app.save!
       @app.set_urls(['http://testapp.vcap.me'])
     end
+    @droplet_entry = {
+        :last_updated => @app.last_updated - 2, # take off 2 seconds so it looks 'quiescent'
+        :state => 'STARTED',
+        :crashes => {},
+        :versions => {},
+        :live_version => @app.package_hash,
+        :instances => @app.instances,
+        :framework => 'sinatra',
+        :runtime => 'ruby19'
+    }
+    @hm.update_droplet(@app)
+  end
+
+  def should_publish_to_nats(message, payload)
+    NATS.should_receive(:publish).with(message, payload.to_json)
   end
 
   after(:all) do
@@ -41,7 +56,9 @@ describe HealthManager do
   before(:each) do
     @hm = HealthManager.new({
       'mbus' => 'nats://localhost:4222/',
-      'log_level' => 'FATAL',
+      'logging' => {
+        'level' => 'fatal',
+      },
       'intervals' => {
         'database_scan' => 1,
         'droplet_lost' => 3,
@@ -50,6 +67,14 @@ describe HealthManager do
         'flapping_timeout' => 5,
         'restart_timeout' => 2,
         'stable_state' => 1
+      },
+      'rails_environment' => 'test',
+      'database_environment' => {
+        'test' => {
+          'adapter' => 'sqlite3',
+          'database' => 'db/test.sqlite3',
+          'encoding' => 'utf8'
+        }
       }
     })
 
@@ -58,6 +83,9 @@ describe HealthManager do
     build_user_and_app
 
     silence_warnings { NATS = mock("NATS") }
+  end
+
+  pending "should not do anything when everything is running" do
     NATS.should_receive(:start).with(:uri => 'nats://localhost:4222/')
 
     NATS.should_receive(:subscribe).with('dea.heartbeat').and_return { |_, block| @hb_block = block }
@@ -69,9 +97,7 @@ describe HealthManager do
 
     NATS.should_receive(:subscribe).with('vcap.component.discover')
     NATS.should_receive(:publish).with('vcap.component.announce', /\{.*\}/)
-  end
 
-  pending "should not do anything when everything is running" do
     EM.run do
       @hm.stub!(:register_error_handler)
       @hm.run
@@ -106,5 +132,22 @@ describe HealthManager do
         EM.stop_event_loop
       end
     end
+  end
+
+  it "should detect instances that are down and send a START request" do
+    stats = { :frameworks => {}, :runtimes => {}, :down => 0 }
+    should_publish_to_nats "cloudcontrollers.hm.requests", {
+          'droplet' => 1,
+          'op' => 'START',
+          'last_updated' => @app.last_updated.to_i,
+          'version' => @app.staged_package_hash+"-0",
+          'indices' => [0,1,2]
+        }
+
+    @hm.analyze_app(@app.id, @droplet_entry, stats)
+
+    stats[:down].should == 3
+    stats[:frameworks]['sinatra'][:missing_instances].should == 3
+    stats[:runtimes]['ruby19'][:missing_instances].should == 3
   end
 end

--- a/health_manager/spec/health_manager_spec.rb
+++ b/health_manager/spec/health_manager_spec.rb
@@ -36,7 +36,7 @@ describe HealthManager do
         :state => 'STARTED',
         :crashes => {},
         :versions => {},
-        :live_version => @app.package_hash,
+        :live_version => "#{@app.staged_package_hash}-#{@app.run_count}",
         :instances => @app.instances,
         :framework => 'sinatra',
         :runtime => 'ruby19'
@@ -83,6 +83,17 @@ describe HealthManager do
     build_user_and_app
 
     silence_warnings { NATS = mock("NATS") }
+  end
+
+  def make_heartbeat_message(indices, state)
+    droplets = []
+    indices.each do |index|
+      droplets << {
+          'droplet' => @app.id, 'index' => index, 'instance' => index, 'state' => state,
+          'version' => @droplet_entry[:live_version], 'state_timestamp' => @droplet_entry[:last_updated]
+      }
+    end
+    { 'droplets' => droplets }.to_json
   end
 
   pending "should not do anything when everything is running" do
@@ -140,7 +151,7 @@ describe HealthManager do
           'droplet' => 1,
           'op' => 'START',
           'last_updated' => @app.last_updated.to_i,
-          'version' => @app.staged_package_hash+"-0",
+          'version' => "#{@app.staged_package_hash}-#{@app.run_count}",
           'indices' => [0,1,2]
         }
 
@@ -176,13 +187,7 @@ describe HealthManager do
   end
 
   it "should update its internal state to reflect heartbeat messages" do
-    droplet = {
-        'droplet' => @app.id, 'index' => 0, 'instance' => 0, 'state' => 'RUNNING',
-        'version' => @droplet_entry[:live_version], 'state_timestamp' => @droplet_entry[:last_updated]
-    }
-    message = { 'droplets' => [droplet] }
-
-    droplet_entries = @hm.process_heartbeat_message(message.to_json)
+    droplet_entries = @hm.process_heartbeat_message(make_heartbeat_message([0], "RUNNING"))
 
     droplet_entries.size.should == 1
     droplet_entry = droplet_entries[0]
@@ -192,5 +197,32 @@ describe HealthManager do
     index_entry = version_entry[:indices][0]
     index_entry.should_not be_nil
     index_entry[:state].should == 'RUNNING'
+  end
+
+  it "should restart an instance that exits unexpectedly" do
+    should_publish_to_nats "cloudcontrollers.hm.requests", {
+          'droplet' => 1,
+          'op' => 'START',
+          'last_updated' => @app.last_updated.to_i,
+          'version' => "#{@app.staged_package_hash}-#{@app.run_count}",
+          'indices' => [0]
+        }
+
+    @hm.process_heartbeat_message(make_heartbeat_message([0], "RUNNING"))
+    droplet_entry = @hm.process_exited_message({
+                                                     'droplet' => 1,
+                                                     'version' => "#{@app.staged_package_hash}-#{@app.run_count}",
+                                                     'index' => 0,
+                                                     'instance' => 0,
+                                                     'reason' => 'CRASHED',
+                                                     'crash_timestamp' => Time.now.to_i
+                                                 }.to_json)
+
+    droplet_entry[:versions].should_not be_nil
+    version_entry = droplet_entry[:versions][@droplet_entry[:live_version]]
+    version_entry.should_not be_nil
+    index_entry = version_entry[:indices][0]
+    index_entry.should_not be_nil
+    index_entry[:state].should == 'DOWN'
   end
 end


### PR DESCRIPTION
These commits add some rspec tests to the health_manager. It verifies that the health manager:
- detects instances that are down, and sends a START request over NATS
- detects extra instances, and send a STOP request over NATS
- updates its internal state when receiving heartbeat messages
- restarts instances that exit unexpectedly

This increases the code coverage of health_manager.rb to around 50%.
