### PR TITLE
fixed a bug in dev_setup/cookbooks/cloud_controller/templates

### DIFF
--- a/dev_setup/cookbooks/cloud_controller/templates/default/cloud_controller.yml.erb
+++ b/dev_setup/cookbooks/cloud_controller/templates/default/cloud_controller.yml.erb
@@ -82,7 +82,7 @@ staging:
   secure: false
 
 # admin support
-admins: [ <%= node[:cloud_controller][:admins].join(",") %> ]
+admins: [ <%= node[:cloud_controller][:admins].join(", ") %> ]
 https_required: false
 https_required_for_admins: false
 


### PR DESCRIPTION
The line outputed by the template doesn't work.

admins: [ hoge@example.com,fuga@example.com ]

YAML.load("admins: [ hoge@example.com,fuga@example.com ]")
=> {"admins"=>["hoge@example.com,fuga@example.com"]} # only 1 admin user
