### PR TITLE
Fix rvm installation problem in setup/install.

### DIFF
--- a/setup/install
+++ b/setup/install
@@ -31,7 +31,7 @@ read -p "Enter the password you want to use for root postgresql user: " POSTGRES
 echo "Installing dependencies"
 if [[ $PLATFORM == 'Linux' ]]; then
   sudo apt-get update
-  sudo apt-get -qqy install coreutils autoconf curl git-core ruby bison build-essential zlib1g-dev libssl-dev libreadline5-dev
+  sudo apt-get -qqy install coreutils autoconf libtool curl git-core ruby bison build-essential zlib1g-dev libssl-dev libreadline5-dev
 else
   echo "Sorry, we can't install dependencies for your system yet."
 fi


### PR DESCRIPTION
I have install vcap from github/master today.
The following error has occurred while running rvm install via setup/install.

<pre>
Extracting yaml-0.1.4.tar.gz to /home/vcap/.rvm/src
Configuring yaml in /home/vcap/.rvm/src/yaml-0.1.4.
Compiling yaml in /home/vcap/.rvm/src/yaml-0.1.4.
ERROR: Error running 'make ', please read /home/vcap/.rvm/log/ruby-1.9.2-p180/yaml/make.log
Installing yaml to /home/vcap/.rvm/usr
ERROR: Error running 'make install', please read /home/vcap/.rvm/log/ruby-1.9.2-p180/yaml/make.install.log
ruby-1.9.2-p180 - #configuring
</pre>


in a log 

<pre>
src/Makefile.am:2: Libtool library used but `LIBTOOL' is undefined
src/Makefile.am:2:   The usual way to define `LIBTOOL' is to add `AC_PROG_LIBTOOL'
src/Makefile.am:2:   to `configure.ac' and run `aclocal' and `autoconf' again.
src/Makefile.am:2:   If `AC_PROG_LIBTOOL' is in `configure.ac', make sure
src/Makefile.am:2:   its definition is in aclocal's search path.
</pre>


libtool is required to make yaml.
I added libtool to the install packages in setup/install. 
