### PR TITLE
Custom domains for dev_setup/bin/vcap_dev_setup

### DIFF
--- a/dev_setup/README
+++ b/dev_setup/README
@@ -63,5 +63,12 @@ o To use a custom deployment config
    To Stop:
       $HOME/projects/vcap/dev_setup/bin/vcap_dev -d $HOME/projects -n dea stop
 
+o To use a custom domain
+  e.g. If you do not want your CloudFoundry domain as vcap.em
+  $HOME/projects/vcap/dev_setup/bin/vcap_dev_setup -D myowndomain.com
+  
+  Later, you will target your CloudFoundry installation with:
+    vmc target api.myowndomain.com
+  
 NOTE: To learn more about custom deployment config files and multi host setups
 see the README file vcap/dev_setup/deployments/README.

--- a/dev_setup/bin/vcap_dev_setup
+++ b/dev_setup/bin/vcap_dev_setup
@@ -12,6 +12,7 @@ OPTIONS:
   -p           http proxy i.e. -p http://username:password@host:port/
   -c           deployment config
   -d           cloudfoundry home
+  -D           cloudfoundry domain (default: vcap.me)
   -r           cloud foundry repo
   -b           cloud foundry repo branch/tag/SHA
 EOF
@@ -43,6 +44,9 @@ do
     d)
       CLOUDFOUNDRY_HOME=$OPTARG
       ;;
+    D)
+      CLOUDFOUNDRY_DOMAIN=$OPTARG
+      ;;
     r)
       VCAP_REPO=$OPTARG
       ;;
@@ -58,6 +62,10 @@ done
 
 if [ -z "$CLOUDFOUNDRY_HOME" ]; then
   CLOUDFOUNDRY_HOME=~/cloudfoundry
+fi
+
+if [ -z "$CLOUDFOUNDRY_DOMAIN" ]; then
+  CLOUDFOUNDRY_DOMAIN=vcap.me
 fi
 
 if [ -z "$VCAP_REPO" ]; then
@@ -128,6 +136,10 @@ fi
 ARGS=""
 if [ -n "$CLOUDFOUNDRY_HOME" ]; then
   ARGS="-d $CLOUDFOUNDRY_HOME"
+fi
+
+if [ -n "$CLOUDFOUNDRY_DOMAIN" ]; then
+  ARGS="$ARGS -D $CLOUDFOUNDRY_DOMAIN"
 fi
 
 if [ -n "$CONFIG_FILE" ]; then

--- a/dev_setup/bin/vcap_dev_setup
+++ b/dev_setup/bin/vcap_dev_setup
@@ -28,7 +28,7 @@ fi
 
 APT_CONFIG="-o Acquire::http::No-Cache=True -o Acquire::BrokenProxy=true -o Acquire::Retries=3"
 
-while getopts "had:p:c:r:b:" OPTION
+while getopts "had:p:c:D:r:b:" OPTION
 do
   case $OPTION in
     h)

--- a/dev_setup/cookbooks/nginx/templates/default/ubuntu-nginx.conf.erb
+++ b/dev_setup/cookbooks/nginx/templates/default/ubuntu-nginx.conf.erb
@@ -44,7 +44,7 @@ http {
 
     server {
         listen       *:80;
-        server_name  "<%= node[:deployment][:domain] %>";
+        server_name  _;
 
         access_log   <%= node[:nginx][:vcap_log] %> main;
         server_name_in_redirect off;

--- a/dev_setup/lib/chefsolo_launch.rb
+++ b/dev_setup/lib/chefsolo_launch.rb
@@ -15,12 +15,14 @@ require File.expand_path('job_manager', File.dirname(__FILE__))
 
 script_dir = File.expand_path(File.dirname(__FILE__))
 cloudfoundry_home = Deployment.get_cloudfoundry_home
+cloudfoundry_domain = Deployment.get_cloudfoundry_domain
 deployment_spec = File.expand_path(File.join(script_dir, "..", DEPLOYMENT_DEFAULT_SPEC))
 
 args = ARGV.dup
 opts_parser = OptionParser.new do |opts|
   opts.on('--config CONFIG_FILE', '-c CONFIG_FILE') { |file| deployment_spec = File.expand_path(file.to_s) }
   opts.on('--dir CLOUDFOUNDRY_HOME', '-d CLOUDFOUNDRY_HOME') { |dir| cloudfoundry_home = File.expand_path(dir.to_s) }
+  opts.on('--domain CLOUDFOUNDRY_DOMAIN', '-D CLOUDFOUNDRY_DOMAIN') { |domain| cloudfoundry_domain = domain }
 end
 args = opts_parser.parse!(args)
 
@@ -37,6 +39,7 @@ spec["deployment"] ||= {}
 spec["deployment"]["name"] ||= DEPLOYMENT_DEFAULT_NAME
 spec["deployment"]["user"] ||= ENV["USER"]
 spec["deployment"]["group"] ||= `id -g`.strip
+spec["deployment"]["domain"] ||= cloudfoundry_domain
 spec["cloudfoundry"] ||= {}
 spec["cloudfoundry"]["home"] ||= cloudfoundry_home
 spec["cloudfoundry"]["home"] = File.expand_path(spec["cloudfoundry"]["home"])

--- a/dev_setup/lib/vcap_defs.rb
+++ b/dev_setup/lib/vcap_defs.rb
@@ -34,6 +34,7 @@ end
 
 DEPLOYMENT_DEFAULT_SPEC = File.join("deployments", "devbox.yml")
 DEPLOYMENT_DEFAULT_NAME = "devbox"
+DEPLOYMENT_DEFAULT_DOMAIN = "vcap.me"
 DEPLOYMENT_CONFIG_DIR_NAME = "config"
 DEPLOYMENT_CONFIG_FILE_NAME = "deploy.json"
 DEPLOYMENT_VCAP_CONFIG_FILE_NAME = "vcap_components.json"
@@ -46,6 +47,10 @@ class Deployment
   class << self
     def get_cloudfoundry_home
       File.expand_path(File.join(ENV["HOME"], "cloudfoundry"))
+    end
+
+    def get_cloudfoundry_domain
+      DEPLOYMENT_DEFAULT_DOMAIN
     end
 
     def get_config_path(name, cloudfoundry_home=nil)


### PR DESCRIPTION
The cookbooks support a custom domain, but the vcap_dev_setup wrapper script does not. This branch adds a -D flag to vcap_dev_setup to declare what your domain will be.

Includes an update to the dev_setup/README
