### PR TITLE
User info returns if is an admin

### DIFF
--- a/cloud_controller/app/controllers/users_controller.rb
+++ b/cloud_controller/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
     target_user = ::User.find_by_email(params['email'])
     if target_user
       if target_user.email == user.email || @current_user.admin?
-        render :json => { :email => target_user.email }
+        render :json => { :email => target_user.email, :admin => target_user.admin? }
       else
         raise CloudError.new(CloudError::FORBIDDEN)
       end

--- a/cloud_controller/spec/controllers/users_controller_spec.rb
+++ b/cloud_controller/spec/controllers/users_controller_spec.rb
@@ -18,6 +18,7 @@ describe UsersController do
       json = Yajl::Parser.parse(response.body)
       json.should be_kind_of(Hash)
       json['email'].should == @user.email
+      json['admin'].should == @user.admin?
     end
 
     it 'should return an user info as an admin requesting for an existent user' do
@@ -29,6 +30,7 @@ describe UsersController do
       json = Yajl::Parser.parse(response.body)
       json.should be_kind_of(Hash)
       json['email'].should == @user.email
+      json['admin'].should == @user.admin?
     end
 
     it 'should return an error as an admin requesting for a non-existent user' do


### PR DESCRIPTION
When using an outside client (like vmc or cloudfoundry-client), the only way to know if a user is an admin user is retrieving the list of all users, as it returns for each user its email, owned apps and whether is an admin or not, but you must be an admin user to do that. If you invoke the user info method, it only returns its email.

There're some use cases where I want to know if the user logged in is an admin or not, and based on that information I allow or deny him to perform some actions without the need to invoke the api and capture the exception (so it means he isn't an admin).

This branch adds admin info when retrieving user info, as the list users method does.  
