### PR TITLE
HealthManager should exit on detecting an error on eventmachine.

### DIFF
--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -149,6 +149,7 @@ class HealthManager
       @logger.error "Eventmachine problem, #{e}"
       @logger.error("#{e.backtrace.join("\n")}")
       @logger.error(e)
+      exit!
     end
 
     NATS.start(:uri => @config['mbus']) do


### PR DESCRIPTION
For example, if database connection failed due to the failure on the database server,
HM just logs:

```
ERROR -- ActiveRecord::StatementInvalid("PGError: ...
```

and no recovery actions are taken so that we happen to fall into the infinite loop of errors,
after the database server is recovered.
(In this case, we need to repair HM by rebooting it's process manually....)

I added 'exit!' to reduce this manual operation.
