### PR TITLE
Fix Ruby recipe file for latest version of Chef

### DIFF
--- a/dev_setup/cookbooks/ruby/recipes/ruby18.rb
+++ b/dev_setup/cookbooks/ruby/recipes/ruby18.rb
@@ -1,13 +1,37 @@
-orig_version = node[:ruby][:version]
-orig_source = node[:ruby][:source]
-orig_path = node[:ruby][:path]
-
-node[:ruby][:version] = node[:ruby18][:version]
-node[:ruby][:source] = node[:ruby18][:source]
-node[:ruby][:path] = node[:ruby18][:path]
+ruby_version = node[:ruby18][:version]
+ruby_source = node[:ruby18][:source]
+ruby_path = node[:ruby18][:path]
+rubygems_version = node[:rubygems][:version]
+bundler_version = node[:rubygems][:bundler][:version]
+rake_version = node[:rubygems][:rake][:version]
 
 include_recipe "ruby::default"
 
-node[:ruby][:version] = orig_version
-node[:ruby][:source] = orig_source
-node[:ruby][:path] = orig_path
+bash "Install Ruby 1.8" do
+  cwd File.join("", "tmp")
+  user node[:deployment][:user]
+  code <<-EOH
+  tar xzf ruby-#{ruby_version}.tar.gz
+  cd ruby-#{ruby_version}
+  ./configure --disable-pthread --prefix=#{ruby_path}
+  make
+  make install
+  EOH
+  not_if do
+    ::File.exists?(File.join(ruby_path, "bin", "ruby"))
+  end
+end
+
+bash "Install RubyGems for Ruby 1.8" do
+  cwd File.join("", "tmp")
+  user node[:deployment][:user]
+  code <<-EOH
+  tar xzf rubygems-#{rubygems_version}.tgz
+  cd rubygems-#{rubygems_version}
+  #{File.join(ruby_path, "bin", "ruby")} setup.rb
+  EOH
+  not_if do
+    ::File.exists?(File.join(ruby_path, "bin", "gem")) &&
+        system("#{File.join(ruby_path, "bin", "gem")} -v | grep -q '#{rubygems_version}$'")
+  end
+end

--- a/dev_setup/cookbooks/ruby/recipes/ruby18.rb
+++ b/dev_setup/cookbooks/ruby/recipes/ruby18.rb
@@ -5,7 +5,23 @@ rubygems_version = node[:rubygems][:version]
 bundler_version = node[:rubygems][:bundler][:version]
 rake_version = node[:rubygems][:rake][:version]
 
-include_recipe "ruby::default"
+%w[ build-essential libssl-dev zlib1g-dev libreadline5-dev libxml2-dev libpq-dev].each do |pkg|
+  package pkg
+end
+
+remote_file File.join("", "tmp", "ruby-#{ruby_version}.tar.gz") do
+  owner node[:deployment][:user]
+  source ruby_source
+  not_if { ::File.exists?(File.join("", "tmp", "ruby-#{ruby_version}.tar.gz")) }
+end
+
+directory ruby_path do
+  owner node[:deployment][:user]
+  group node[:deployment][:group]
+  mode "0755"
+  recursive true
+  action :create
+end
 
 bash "Install Ruby 1.8" do
   cwd File.join("", "tmp")
@@ -22,6 +38,12 @@ bash "Install Ruby 1.8" do
   end
 end
 
+remote_file File.join("", "tmp", "rubygems-#{rubygems_version}.tgz") do
+  owner node[:deployment][:user]
+  source "http://production.cf.rubygems.org/rubygems/rubygems-#{rubygems_version}.tgz"
+  not_if { ::File.exists?(File.join("", "tmp", "rubygems-#{rubygems_version}.tgz")) }
+end
+
 bash "Install RubyGems for Ruby 1.8" do
   cwd File.join("", "tmp")
   user node[:deployment][:user]
@@ -33,5 +55,24 @@ bash "Install RubyGems for Ruby 1.8" do
   not_if do
     ::File.exists?(File.join(ruby_path, "bin", "gem")) &&
         system("#{File.join(ruby_path, "bin", "gem")} -v | grep -q '#{rubygems_version}$'")
+  end
+end
+
+gem_package "bundler" do
+  version bundler_version
+  gem_binary File.join(ruby_path, "bin", "gem")
+end
+
+gem_package "rake" do
+  version rake_version
+  gem_binary File.join(ruby_path, "bin", "gem")
+end
+
+# The default chef installed with Ubuntu 10.04 does not support the "retries" option
+# for gem_package. It may be a good idea to add/use that option once the ubuntu
+# chef package gets updated.
+%w[ rack eventmachine thin sinatra mysql pg vmc ].each do |gem|
+  gem_package gem do
+    gem_binary File.join(ruby_path, "bin", "gem")
   end
 end


### PR DESCRIPTION
I have install vcap via vcap_dev_setup for setup multi node vcap development environment.
while running install ruby 1.8, The error like following link has occurred.

http://support.cloudfoundry.com/entries/20767116-ruby-1-8-7-p334-missing-in-installation-using-chef

I tried the solution Vlad provided, but Problem was not solved.
I investigate the cause of error, I found that bash resource name conflict is the cause.

In the mean time, I created a workaround patch to fix this problem.

Thanks.
