### PR TITLE
Add service name uri validation in cloud_controller

### DIFF
--- a/cloud_controller/app/controllers/legacy_services_controller.rb
+++ b/cloud_controller/app/controllers/legacy_services_controller.rb
@@ -49,6 +49,12 @@ class LegacyServicesController < ApplicationController
     req = LegacyVmcMessages::ProvisionRequest.decode(request_body)
     @event_args = [req.vendor, req.name]
 
+    begin
+      URI.parse(req.name)
+    rescue URI::InvalidURIError
+      raise CloudError.new(CloudError::URI_INVALID, req.name)
+    end
+
     label = req.vendor + "-" + req.version
     svc = ::Service.find_by_label(label)
     # Legacy api fell back to matching by vendor if no version matched

--- a/cloud_controller/app/controllers/services_controller.rb
+++ b/cloud_controller/app/controllers/services_controller.rb
@@ -154,6 +154,12 @@ class ServicesController < ApplicationController
   def provision
     req = VCAP::Services::Api::CloudControllerProvisionRequest.decode(request_body)
 
+    begin
+      URI.parse(req.name)
+    rescue URI::InvalidURIError
+      raise CloudError.new(CloudError::URI_INVALID, req.name)
+    end
+
     svc = Service.find_by_label(req.label)
     raise CloudError.new(CloudError::SERVICE_NOT_FOUND) unless svc && svc.visible_to_user?(user)
 

--- a/cloud_controller/spec/controllers/services_controller_spec.rb
+++ b/cloud_controller/spec/controllers/services_controller_spec.rb
@@ -447,6 +447,20 @@ describe ServicesController do
 
         stop_gateway(gw_pid)
       end
+
+      it 'should fail to provision with invalid uri service name' do
+        shim = ServiceProvisionerStub.new
+        shim.stubs(:provision_service).returns({:data => {}, :service_id => 'foo', :credentials => {}})
+        gw_pid = start_gateway(@svc, shim)
+        post_msg :provision do
+          VCAP::Services::Api::CloudControllerProvisionRequest.new(
+            :label => 'foo-bar',
+            :name  => '[',
+            :plan  => 'free')
+        end
+        response.status.should == 400
+        stop_gateway(gw_pid)
+      end
     end
 
     describe "#bind" do


### PR DESCRIPTION
Once create a service that name has a invalid uri, we cannot delete the service.

$ vmc create-service redis "[test]" 
Creating Service: OK

$ vmc delete-service "[test]" 
Deleting service test: Cannot access target (bad URI: http://api.cloudfoundry.com/services/[test])

This patch fix the problem to validate service name uri before provisioning.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
