### PR TITLE
Fixed bug in chef receipe with multiple ruby versions

### DIFF
--- a/dev_setup/cookbooks/ruby/recipes/default.rb
+++ b/dev_setup/cookbooks/ruby/recipes/default.rb
@@ -23,7 +23,7 @@ directory ruby_path do
   action :create
 end
 
-bash "Install Ruby" do
+bash "Install Ruby #{ruby_version} in #{ruby_path}" do
   cwd File.join("", "tmp")
   user node[:deployment][:user]
   code <<-EOH
@@ -44,7 +44,7 @@ remote_file File.join("", "tmp", "rubygems-#{rubygems_version}.tgz") do
   not_if { ::File.exists?(File.join("", "tmp", "rubygems-#{rubygems_version}.tgz")) }
 end
 
-bash "Install RubyGems" do
+bash "Install RubyGems #{rubygems_version} for #{ruby_path}" do
   cwd File.join("", "tmp")
   user node[:deployment][:user]
   code <<-EOH


### PR DESCRIPTION
In my attempts to install vcap with the dev_setup/chef method, I ran into an issue where chef would not correctly install ruby 1.8 after 1.9, and it seems the reason was because the same receipe was invoked twice, but somehow skipped the 2nd time around.

This patch fixes it by making sure the bash steps end up named differently with the ruby version number.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
