### PR TITLE
Small improvement to specify supported runtimes and frameworks in App model (DRY)

### DIFF
--- a/cloud_controller/app/models/app.rb
+++ b/cloud_controller/app/models/app.rb
@@ -23,8 +23,12 @@ class App < ActiveRecord::Base
 
   AppStates = %w[STOPPED STARTED]
   PackageStates = %w[PENDING STAGED FAILED]
-  Runtimes = %w[ruby18 ruby19 java node php erlangR14B02 python26]
-  Frameworks = %w[sinatra rails3 java_web spring grails node php otp_rebar lift wsgi django unknown]
+
+  # Defined at cloud_controller.yml
+  Runtimes = AppConfig[:runtimes].keys.map {|k| k.to_s}
+
+  # Supported frameworks that have a manifest file
+  Frameworks = StagingPlugin.manifests_info.keys.map {|k| k.to_s} << 'unknown'  
 
   validates_presence_of :name, :framework, :runtime
 

--- a/health_manager/lib/health_manager.rb
+++ b/health_manager/lib/health_manager.rb
@@ -30,6 +30,7 @@ module CloudController
     $:.unshift(lib_dir.to_s) unless $:.include?(lib_dir.to_s)
     $:.unshift(common_lib_dir) unless $:.include?(common_lib_dir)
     require root.join('config', 'boot')
+    require root.join('config', 'initializers', 'staging')
     require 'active_record'
     require 'active_support/core_ext'
     require 'yajl'


### PR DESCRIPTION
Currently the supported runtimes and frameworks already specified in `cloud_controller/config/cloud_controller.yml` and `staging/lib/vcap/manifests/*` respectively, are hard coded in the App model at ~cloud_controller/app/models/app.rb~.

With this patch, this duplication will be avoided, making easier to specify which runtimes and frameworks are supported without having to modify the App model directly.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
