### PR TITLE
Root's hidden files lost between droplet package and staging

### DIFF
--- a/cloud_controller/app/models/app_package.rb
+++ b/cloud_controller/app/models/app_package.rb
@@ -40,10 +40,10 @@ class AppPackage
   def self.repack_app_in(dir, tmpdir, format)
     if format == :zip
       target_path = File.join(tmpdir, 'app.zip')
-      cmd = "cd #{dir}; zip -q -y #{target_path} -r * 2>&1"
+      cmd = "cd #{dir}; zip -q -y #{target_path} -r . 2>&1"
     else
       target_path = File.join(tmpdir, 'app.tgz')
-      cmd = "cd #{dir}; COPYFILE_DISABLE=true tar -czf #{target_path} * 2>&1"
+      cmd = "cd #{dir}; COPYFILE_DISABLE=true tar -czf #{target_path} . 2>&1"
     end
 
     timed_section(CloudController.logger, 'repack_app') do

--- a/staging/lib/vcap/staging/plugin/common.rb
+++ b/staging/lib/vcap/staging/plugin/common.rb
@@ -509,7 +509,7 @@ echo "$STARTED" >> ../run.pid
 
   def copy_source_files(dest = nil)
     dest ||= File.join(destination_directory, 'app')
-    system "cp -a #{File.join(source_directory, "*")} #{dest}"
+    system "cp -a #{File.join(source_directory, ".")} #{dest}"
   end
 
   def detection_rules


### PR DESCRIPTION
Hi,

I've noticed that the files beginning by a dot at the root of my app weren't deployed to the DEA.
That's necessary for .htaccess files in some php apps and may be for other use cases.

The files were uploaded to the cloud controller but were lost in packaging and copying.

Jean-Sébastien TremblayDear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
