### PR TITLE
Small improvement for vmc manifest command.

### DIFF
--- a/staging/lib/vcap/staging/plugin/common.rb
+++ b/staging/lib/vcap/staging/plugin/common.rb
@@ -72,7 +72,6 @@ class StagingPlugin
     `env -i PATH=#{ENV['PATH']} #{exe} #{get_ver}`
   end
 
-
   # Transforms lowercased/underscored word into camelcase.
   #
   # EX: camelize('foo_bar') returns 'FooBar'
@@ -119,6 +118,7 @@ class StagingPlugin
         runtime.each_pair do |runtime_name, runtime_info|
           runtimes <<  {
             :name => runtime_name,
+            :default => runtime_info['default'],
             :version => runtime_info['version'],
             :description => runtime_info['description'] }
         end

--- a/staging/spec/unit/multiple_runtimes_frameworks_spec.rb
+++ b/staging/spec/unit/multiple_runtimes_frameworks_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "A Framework should be able to have multiple runtimes" do
+
+  before do
+    sinatra_path = File.join(STAGING_TEMP, 'sinatra.yml')
+    sinatra_manifest = File.read(sinatra_path)
+    File.open(sinatra_path, 'w') {|f| f.write(sinatra_manifest) }
+    StagingPlugin.load_all_manifests
+    @manifests = StagingPlugin.manifests
+  end
+
+  it 'should list multiple rutimes' do
+    runtime_names = []
+    @manifests['sinatra']['runtimes'].each do |r|
+      r.each_pair do |rt_name, rt_info|
+        runtime_names << rt_name
+      end
+    end
+    runtime_names.should include 'ruby18', 'ruby19'
+  end
+
+  it 'should list a default runtime' do
+    defaults = []
+    @manifests['sinatra']['runtimes'].each do |r|
+      r.each_pair do |rt_name, rt_info|
+        defaults << rt_info['default']
+      end
+    end
+    defaults.select{ |d| d == true }.size.should eq 1
+  end
+
+end


### PR DESCRIPTION
Hi.

This pull request is small improvement for vmc manifest command.

Currently, vmc is not able to know a default runtime for frameworks.
Because, StagingPlugin.manifests_info does not expose information about defalut runtime for framework.

This improvement adds default runtime info to manifest info that StagingPlugin expose.

The above improvements, vmc will be able to know the default runtime for frameworks.

Thanks.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
