### PR TITLE
Added Rack framework support

### DIFF
--- a/cloud_controller/app/models/app.rb
+++ b/cloud_controller/app/models/app.rb
@@ -24,7 +24,7 @@ class App < ActiveRecord::Base
   AppStates = %w[STOPPED STARTED]
   PackageStates = %w[PENDING STAGED FAILED]
   Runtimes = %w[ruby18 ruby19 java node php erlangR14B02 python26]
-  Frameworks = %w[sinatra rails3 java_web spring grails node php otp_rebar lift wsgi django unknown]
+  Frameworks = %w[sinatra rack rails3 java_web spring grails node php otp_rebar lift wsgi django unknown]
 
   validates_presence_of :name, :framework, :runtime
 

--- a/staging/lib/vcap/staging/plugin/manifests/rack.yml
+++ b/staging/lib/vcap/staging/plugin/manifests/rack.yml
@@ -1,5 +1,5 @@
 ---
-name: "sinatra"
+name: "rack"
 runtimes:
   - "ruby18":
       version: "1.8.7" # FIXME change to 1.8.7-p334
@@ -24,8 +24,7 @@ app_servers:
       executable: false # determined during staging
       default: true
 detection:
-  - "*.rb": "require 'sinatra'|require \"sinatra\"" # .rb files in the root dir containing a require?
-  - "config.ru": false # use rack if it detects a config.ru
+  - "config.ru": true
   - "config/environment.rb": false # and config/environment.rb must not exist
 staged_services:
   - "name": "mysql"

--- a/staging/lib/vcap/staging/plugin/rack/plugin.rb
+++ b/staging/lib/vcap/staging/plugin/rack/plugin.rb
@@ -1,0 +1,64 @@
+class RackPlugin < StagingPlugin
+  include GemfileSupport
+  def framework
+    'rack'
+  end
+
+  def stage_application
+    Dir.chdir(destination_directory) do
+      create_app_directories
+      copy_source_files
+      compile_gems
+      create_startup_script
+      create_stop_script
+    end
+  end
+
+  def start_command
+    if uses_bundler?
+      "#{local_runtime} ./rubygems/ruby/#{library_version}/bin/bundle exec #{local_runtime} -S rackup $@ config.ru"
+    else
+      "#{local_runtime} -S rackup $@ config.ru"
+    end
+  end
+
+  private
+  def startup_script
+    vars = environment_hash
+    if uses_bundler?
+      vars['PATH'] = "$PWD/app/rubygems/ruby/#{library_version}/bin:$PATH"
+      vars['GEM_PATH'] = vars['GEM_HOME'] = "$PWD/app/rubygems/ruby/#{library_version}"
+      vars['RUBYOPT'] = '-I$PWD/ruby -rstdsync'
+    else
+      vars['RUBYOPT'] = "-rubygems -I$PWD/ruby -rstdsync"
+    end
+    # PWD here is after we change to the 'app' directory.
+    generate_startup_script(vars) do
+      plugin_specific_startup
+    end
+  end
+
+  def stop_script
+    vars = environment_hash
+    generate_stop_script(vars)
+  end
+
+  def plugin_specific_startup
+    cmds = []
+    cmds << "mkdir ruby"
+    cmds << 'echo "\$stdout.sync = true" >> ./ruby/stdsync.rb'
+    cmds.join("\n")
+  end
+
+  # TODO - I'm fairly sure this problem of 'no standard startup command' is
+  # going to be limited to Sinatra and Node.js. If not, it probably deserves
+  # a place in the sinatra.yml manifest.
+  def detect_main_file
+    file = app_files_matching_patterns.first
+    # TODO - Currently staging exceptions are not handled well.
+    # Convert to using exit status and return value on a case-by-case basis.
+    raise "Unable to determine Rack startup command" unless file
+    file
+  end
+end
+

--- a/staging/lib/vcap/staging/plugin/rack/stage
+++ b/staging/lib/vcap/staging/plugin/rack/stage
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../common', __FILE__)
+plugin_class = StagingPlugin.load_plugin_for('rack')
+plugin_class.validate_arguments!
+plugin_class.new(*ARGV).stage_application

--- a/staging/spec/unit/rack_spec.rb
+++ b/staging/spec/unit/rack_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe "A simple Rack app being staged" do
+  before do
+    app_fixture :sinatra_trivial
+  end
+
+  it "is packaged with a startup script" do
+    stage :rack do |staged_dir|
+      executable = '%VCAP_LOCAL_RUNTIME%'
+      start_script = File.join(staged_dir, 'startup')
+      start_script.should be_executable_file
+      script_body = File.read(start_script)
+      script_body.should == <<-EXPECTED
+#!/bin/bash
+export RACK_ENV="production"
+export RAILS_ENV="production"
+export RUBYOPT="-rubygems -I$PWD/ruby -rstdsync"
+unset BUNDLE_GEMFILE
+mkdir ruby
+echo "\\$stdout.sync = true" >> ./ruby/stdsync.rb
+cd app
+#{executable} -S rackup $@ config.ru > ../logs/stdout.log 2> ../logs/stderr.log &
+STARTED=$!
+echo "$STARTED" >> ../run.pid
+wait $STARTED
+      EXPECTED
+    end
+  end
+
+  describe "when bundled" do
+    before do
+      app_fixture :sinatra_gemfile
+    end
+
+    it "is packaged with a startup script" do
+      stage :rack do |staged_dir|
+        executable = '%VCAP_LOCAL_RUNTIME%'
+        start_script = File.join(staged_dir, 'startup')
+        start_script.should be_executable_file
+        script_body = File.read(start_script)
+        script_body.should == <<-EXPECTED
+#!/bin/bash
+export GEM_HOME="$PWD/app/rubygems/ruby/1.8"
+export GEM_PATH="$PWD/app/rubygems/ruby/1.8"
+export PATH="$PWD/app/rubygems/ruby/1.8/bin:$PATH"
+export RACK_ENV="production"
+export RAILS_ENV="production"
+export RUBYOPT="-I$PWD/ruby -rstdsync"
+unset BUNDLE_GEMFILE
+mkdir ruby
+echo "\\$stdout.sync = true" >> ./ruby/stdsync.rb
+cd app
+#{executable} ./rubygems/ruby/1.8/bin/bundle exec #{executable} -S rackup $@ config.ru > ../logs/stdout.log 2> ../logs/stderr.log &
+STARTED=$!
+echo "$STARTED" >> ../run.pid
+wait $STARTED
+      EXPECTED
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
I've added support for rack as a framework for ruby applications.

Rack is useful to have direct support for as simple Sinatra applications can often use other rack mixins, or there are rack-based applications like rack-jekyll or octopress.

Another problem overall with the Sinatra framework is its dependence on a `require 'sinatra'` in the application.  If you have bundler load Sinatra though, it won't detect it:

```
require 'bundler'
Bundler.require
```

The detection of the Rack framework is triggered if there is a 'config.ru' file in the root directory.  I've also changed the Sinatra manifest to specify there shouldn't be a config.ru.  That way, if you have a config.ru, it shouldn't match as a Sinatra application.

The application is started using the simple `rackup` command.  If thin is included, rack will start with thin, however if it isn't present it will fall back on webrick.

To properly use the rack support, your Gemfile needs to include either `rack` or `thin` (thin will imply rack).

I've also documented a quick "Getting Started" app here: http://dev.paas.io/tutorials/ruby-rack
