### PR TITLE
Fix for mysql2 trying to resume a dead fiber

### DIFF
--- a/cloud_controller/vendor/plugins/mysql2_dead_fiber_patch/init.rb
+++ b/cloud_controller/vendor/plugins/mysql2_dead_fiber_patch/init.rb
@@ -1,0 +1,5 @@
+db_config = Rails.application.config.database_configuration[::Rails.env]
+if db_config['adapter'] == 'em_mysql2'
+  require File.expand_path('../mysql2_client_patch', __FILE__)
+  ActiveRecord::ConnectionAdapters.register_fiber_pool(CloudController::UTILITY_FIBER_POOL)
+end

--- a/cloud_controller/vendor/plugins/mysql2_dead_fiber_patch/mysql2_client_patch.rb
+++ b/cloud_controller/vendor/plugins/mysql2_dead_fiber_patch/mysql2_client_patch.rb
@@ -1,0 +1,38 @@
+# This patches an issue identified in mysql2 where an exception thrown down at the
+# database level can kill the fiber, but mysql2 will try to resume it, causing the
+# app to crash.
+#
+# Report here: https://github.com/brianmario/mysql2/issues/188
+#
+# Fiber support was moved to em-sychrony, however CF is on an older eventmachine
+# that won't support em-sychrony, and don't need to add another dependency.
+#
+# A patch was provided in the big that this is based on:
+#   https://gist.github.com/1058768
+module Mysql2
+  module Fibered
+    class Client < ::Mysql2::Client
+      def query(sql, opts={})
+        if ::EM.reactor_running?
+          super(sql, opts.merge(:async => true))
+          deferrable = ::EM::DefaultDeferrable.new
+          ::EM.watch(self.socket, Watcher, self, deferrable).notify_readable = true
+          fiber = Fiber.current
+          deferrable.callback do |result|
+            # Make sure fiber is still alive
+            fiber.resume(result) if fiber.alive?
+          end
+          deferrable.errback do |err|
+            # Make sure fiber is still alive
+            fiber.resume(err) if fiber.alive?
+          end
+          Fiber.yield.tap do |result|
+            raise result if result.is_a?(Exception)
+          end
+        else
+          super(sql, opts)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a patch for an issue I'd experienced with running the cloud controller on MySQL.  The issue was that if an exception was thrown down at the model level or from the database (between when the fiber yielded and was resumed), it would essentially kill the fiber but mysql2 would continue to try to resume it.

Bug: https://github.com/brianmario/mysql2/issues/188

This would end up crashing thin and causing the cloud controller to exit.

Fiber support was moved from mysql2 to em-sychrony.  But em-sychrony requires eventmachine 1.0 and CF is locked on a patched version of eventmachine.

Attached to the bug was a patch (https://gist.github.com/1058768).  It basically just changed it to call `fiber.alive?` before calling resume.

Unfortunately, like my earlier cloud controller pull #172, it is random when it crops up.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
