### PR TITLE
Add update_password_key utility

### DIFF
--- a/cloud_controller/script/update_password_key.rb
+++ b/cloud_controller/script/update_password_key.rb
@@ -1,0 +1,60 @@
+# Copyright (c) 2012 Rakuten, Inc.
+#
+# A utility script for updating password key 
+#
+# If you change password key in cloud_controller.yml, you need to update database records
+# to update the environment column in apps table, which is encrypted.
+#
+# Usage
+#
+#   $ cd CLOUD_CONTROLLER_ROOT
+#   $ CLOUD_CONTROLLER_CONFIG=path/to/cloud_controller.yml path/to/ruby script/rails runner \
+#       script/update_password_key.rb -o 'oldkey' -n 'newkey'
+#
+
+require 'optparse'
+
+old_key = nil
+new_key = nil
+
+opt = OptionParser.new
+opt.on('-o oldkey') { |v| old_key = v }
+opt.on('-n newkey') { |v| new_key = v }
+opt.parse!(ARGV)
+
+if old_key.blank?
+  $stderr.puts "Error: oldkey must be specified."
+  $stderr.puts opt.help
+  exit 1
+end
+
+if new_key.blank?
+  $stderr.puts "Error: newkey must be specified."
+  $stderr.puts opt.help
+  exit 1
+end
+
+App.find(:all).each do |app|
+  json_crypt = app.environment_json
+  environment = if json_crypt.blank?
+                  []
+                else
+                  e = json_crypt.unpack('m*')[0]
+                  d = OpenSSL::Cipher::Cipher.new('blowfish')
+                  d.key = old_key
+                  json = d.update(e)
+                  json << d.final
+                  Yajl::Parser.parse(json)
+                end
+ 
+  json = Yajl::Encoder.encode(environment)
+  c = OpenSSL::Cipher::Cipher.new('blowfish')
+  c.encrypt
+  c.key = new_key
+  json_crypt = c.update(json)
+  json_crypt << c.final 
+  app.environment_json = [json_crypt].pack('m0').gsub("\n", '')
+  app.save!
+  puts "Key Updte DONE: #{app.name} (#{app.id})"
+end
+


### PR DESCRIPTION
Hi,

I added a utility for updating password key in cloud_controller.yml.

Basic scenario of this script is as follows:
- stop the cloud_controller
- run script (update all app records in cloud controller's database).
- start the cloud_controller with new password key.

We considered to add App#update_password_key method, which we dit not take because this script requirement should be the operational one, not functional one, and carefully executed.

Thanks.Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
