### PR TITLE
introduce debug_route and console_route configuration to support debugger

### DIFF
--- a/dea/config/dea.yml
+++ b/dea/config/dea.yml
@@ -13,6 +13,12 @@ droplet_fs_percent_used_threshold: 95
 # value of nil, should work in most cases.
 local_route: 127.0.0.1
 
+# debug_route and console_route is also used to choose the right ip address
+# of the host running the DEA. Debuggers (such as STS plugin) connect the ip
+# address resolved by this route.
+debug_route: 127.0.0.1
+console_route: 127.0.0.1
+
 # Port for accessing the files of running applications
 filer_port: 12345
 

--- a/dea/lib/dea/agent.rb
+++ b/dea/lib/dea/agent.rb
@@ -100,6 +100,8 @@ module DEA
       @runtimes = config['runtimes']
 
       @local_ip     = VCAP.local_ip(config['local_route'])
+      @debug_ip     = VCAP.local_ip(config['debug_route'])
+      @console_ip   = VCAP.local_ip(config['console_route'])
       @max_memory   = config['max_memory'] # in MB
       @multi_tenant = config['multi_tenant']
       @max_clients  = @multi_tenant ? DEFAULT_MAX_CLIENTS : 1
@@ -631,7 +633,7 @@ module DEA
         if debug
           debug_port = grab_port
           if debug_port
-            instance[:debug_ip] = VCAP.local_ip
+            instance[:debug_ip] = @debug_ip
             instance[:debug_port] = debug_port
             instance[:debug_mode] = debug
           else
@@ -644,7 +646,7 @@ module DEA
         if console
           console_port = grab_port
           if console_port
-            instance[:console_ip] = VCAP.local_ip
+            instance[:console_ip] = @console_ip
             instance[:console_port] = console_port
           else
             @logger.warn("Unable to allocate console port for instance#{instance[:log_id]}")


### PR DESCRIPTION
Hi, I found an issue for debug support on DEA.

Running DEA on host that have multiple nics should be supported by setting the correct route settings on 'local_route' configuration. This configuration is used for resolving IP address to communicate routers.

On the other hand, there are lacks of considerations for debug_ip and console_ip so that I'd like to introduce debug_route and console_route configurations as the same manner as local_route.

With this patch, administrator can configure the debugging route for DEA.
Dear Cloud Foundry contributor,

<p>
If you are reading this message, it means you submitted a pull request in the
Cloud Foundry GitHub repository.
</p>


<p>
First of all, thanks! We really appreciate your participation.
</p>


<p>
Recently we made some changes in how we are verifying and reviewing open source
contributions like yours. In addition, we changed the way we can expose our
internal development in real-time. The changes are exciting, as they allow all
our staff to collaborate seamlessly with you, which increases our mutual
velocity and gives the community a bigger stake in our direction.
</p>


<p>
The Cloud Foundry team uses Gerrit, a code review tool that originated in the
Android Open Source Project. We also use GitHub as an official mirror, though
all pull requests are accepted via Gerrit.
</p>


<p>
Follow these steps to make a contribution to any of our open source
repositories:
</p>

1. Complete our CLA Agreement for
   [individuals](http://www.cloudfoundry.org/individualcontribution.pdf) or
   [corporations](http://www.cloudfoundry.org/corpcontribution.pdf).
2. Sign up for an account on our public Gerrit server at
   http://reviews.cloudfoundry.org/.
3. Create and upload your public SSH key in your Gerrit account profile.
4. Set your name and email:
   
   ```
           git config --global user.name "Firstname Lastname"
           git config --global user.email "your_email@youremail.com"
   ```
5. Install our gerrit-cli gem:
   
   ```
           gem install gerrit-cli
   ```
6. Clone the Cloud Foundry repo:
   _Note: to clone the BOSH repo, or the Documentation repo, replace
   `vcap` with `bosh` or `oss-docs`_
   
   ```
           gerrit clone ssh://reviews.cloudfoundry.org:29418/vcap
           cd vcap
   ```
7. Make your changes, commit, and push to gerrit:
   
   ```
           git commit
           gerrit push
   ```

<p>
Once your commits are approved by our Continuous Integration Bot (CI Bot) as
well as our engineering staff, return to the Gerrit interface and MERGE your
changes. The merge will be replicated to GitHub automatically at
https://github.com/cloudfoundry. If you get feedback on your submission, we
recommend squashing your commit with the original change-id. See the squashing
section here for more details: https://help.github.com/rebase.
</p>
