### PR TITLE
FIX chef dependency problem,

### DIFF
--- a/dev_setup/bin/vcap_dev_setup
+++ b/dev_setup/bin/vcap_dev_setup
@@ -133,6 +133,15 @@ if [ ! -f ${GEM} ] || [ `${GEM} -v` \< "1.3.6" ]; then
   cd ${CWD}
 fi
 
+# we need to install net-ssh ans net-ssh-gatewayto avoid dependency problems on chef.
+echo "Installing net-ssh..."
+NET_SSH_VERSION="2.2.2"
+${GEM} list -i net-ssh -v ${NET_SSH_VERSION} || sudo ${GEM} install net-ssh --version ${NET_SSH_VERSION} -q --no-ri --no-rdoc > /dev/null
+
+echo "Installing net-ssh-gateway..."
+NET_SSH_GATEWAY_VERSION=" 1.0.0"
+${GEM} list -i net-ssh-gateway -v ${NET_SSH_GATEWAY_VERSION} || sudo ${GEM} install net-ssh-gateway --version ${NET_SSH_GATEWAY_VERSION} -q --no-ri --no-rdoc > /dev/null
+
 echo "Installing chef..."
 CHEF_VERSION="10.16.4"
 ${GEM} list -i chef -v ${CHEF_VERSION} || sudo ${GEM} install chef --version ${CHEF_VERSION} -q --no-ri --no-rdoc > /dev/null


### PR DESCRIPTION
I tried to intall vcap following the instructions on the README and I got this error:

> Installing chef...
> false
> ERROR:  Error installing chef:
>   net-ssh-gateway requires net-ssh (>= 2.6.5, runtime)

This is because New versions of net-ssh-multi and net-ssh-gateway depend on
net-ssh >= 2.6.4 which breaks chef's dependency on net-ssh ~> 2.2.2.

So, until the chef dependency problem will be fixed we can install net-ssh and net-ssh-gateway before chef and the problem is solved.

Thanks.
