### PR TITLE
Add uaa and uaadb to multihost installation configs

### DIFF
--- a/dev_setup/deployments/sample/multihost_mongodb/rest.yml
+++ b/dev_setup/deployments/sample/multihost_mongodb/rest.yml
@@ -16,6 +16,8 @@ jobs:
         index: "0"
     - redis_gateway
     - ccdb
+    - uaa
+    - uaadb
     - mysql_node:
         index: "0"
     - mysql_gateway

--- a/dev_setup/deployments/sample/multihost_mysql/rest.yml
+++ b/dev_setup/deployments/sample/multihost_mysql/rest.yml
@@ -13,6 +13,8 @@ jobs:
     - stager
     - health_manager
     - ccdb
+    - uaa
+    - uaadb
     - redis_node:
         index: "0"
     - redis_gateway

--- a/dev_setup/deployments/sample/multihost_redis/rest.yml
+++ b/dev_setup/deployments/sample/multihost_redis/rest.yml
@@ -14,6 +14,8 @@ jobs:
     - health_manager
     - redis_gateway
     - ccdb
+    - uaa
+    - uaadb
     - mysql_node:
         index: "0"
     - mysql_gateway


### PR DESCRIPTION
Hello, I suppose mutihost sample installation configs are missing uaa and uaadb. I installed vcap on different machines without uaa and it does not work because of authentication problem. So, I added them into installation configs.
