### PR TITLE
Make cf_local_ip() to use proxy's ip for hint if the machine is behind proxy

### DIFF
--- a/dev_setup/cookbooks/cloudfoundry/libraries/cloudfoundry.rb
+++ b/dev_setup/cookbooks/cloudfoundry/libraries/cloudfoundry.rb
@@ -12,7 +12,10 @@ module CloudFoundry
   end
 
   A_ROOT_SERVER = '198.41.0.4'
-  def cf_local_ip(route = A_ROOT_SERVER)
+  def cf_local_ip
+    if (proxy = ENV["http_proxy"] || ENV["https_proxy"])
+      route = proxy.scan(/\d+.\d+.\d+.\d+/).first
+    end
     route ||= A_ROOT_SERVER
     orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true
     UDPSocket.open {|s| s.connect(route, 1); s.addr.last }

--- a/dev_setup/cookbooks/cloudfoundry/libraries/cloudfoundry.rb
+++ b/dev_setup/cookbooks/cloudfoundry/libraries/cloudfoundry.rb
@@ -13,7 +13,7 @@ module CloudFoundry
 
   A_ROOT_SERVER = '198.41.0.4'
   def cf_local_ip
-    if (proxy = ENV["http_proxy"] || ENV["https_proxy"])
+    if (proxy = ENV["http_proxy"] || ENV["HTTP_PROXY"])
       route = proxy.scan(/\d+.\d+.\d+.\d+/).first
     end
     route ||= A_ROOT_SERVER


### PR DESCRIPTION
cf_local_ip() raises following exception if the machine is not reachable to the Internet.

`Errno::ENETUNREACH: Network is unreachable - connect(2)`

So, if the machine is using proxy to install vcap, cf_local_ip should use its proxy server's address as a hint to know its local address.

Please also note that cf_local_ip does not receive argument for hint ip anymore since I believe it is not very useful.
